### PR TITLE
Add the GD extension as a required dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=5.3.0",
+        "ext-gd": "*"
     },
     "autoload": {
         "psr-0": { "Endroid": "src/" }


### PR DESCRIPTION
The composer.json should include this dependency on the GD extension, since the package requires it.

Otherwise, people who don't have it installed yet (like I didn't) will get a runtime failure instead of being warned at install time.
