### PR TITLE
Remove URL-decoding of the data string, and a pair of unused variables.

### DIFF
--- a/src/Endroid/QrCode/QrCode.php
+++ b/src/Endroid/QrCode/QrCode.php
@@ -333,15 +333,12 @@ class QrCode
      */
     public function create()
     {
-        $target_filename = null;
-        $source_data = $this->text;
-
 		$path=__DIR__.'/../../../assets/data';
 		$image_path=__DIR__.'/../../../assets/image';
 
 		$version_ul=40;
 
-		$qrcode_data_string = $source_data;//Previously from $_GET["d"];
+		$qrcode_data_string = $this->text;//Previously from $_GET["d"];
 
 
 		$qrcode_error_correct = $this->error_correction;//Previously from $_GET["e"];
@@ -362,7 +359,6 @@ class QrCode
 		        $qrcode_module_size=4;
 		    }
 		}
-		$qrcode_data_string=rawurldecode($qrcode_data_string);
 		$data_length=strlen($qrcode_data_string);
 		if ($data_length<=0) {
             throw new DataDoesntExistsException('QRCode: Data does not exists.');


### PR DESCRIPTION
Automatically URL-decoding the text content probably made sense when it was fetched from the query parameters, but since the text is now set from code, I think it is the responsibility of the calling code to do this if it is necessary. Especially since it isn't documented on the setText() method that the text will be decoded when generating the code.

This commit also removes a pair of unused variables I found in the same area. (Well, one was technically used once, but not for anything useful as far as I could tell.)

While I'm at it, I have a question: would you accept pull requests that only do things like clean up the indenting or other code style bits? At the moment the class has a mix of styles, which makes me feel like cleaning it up to be more consistent...

If yes, do you have any particular preferences for styles that I should adhere to?
