### PR TITLE
Removed inadequate "die" statement while rendering

### DIFF
--- a/src/Endroid/QrCode/QrCode.php
+++ b/src/Endroid/QrCode/QrCode.php
@@ -289,7 +289,6 @@ class QrCode
 
         if ($filename === null) {
             imagepng($this->image);
-            die;
         } else {
             imagepng($this->image, $filename);
         }


### PR DESCRIPTION
When called in a context where other code is expected to be executed after rendering (i. e. in a MVC app where some shutdown stuff is to be done after preparing the response), a "die" within third party code leads to unexpected behaviour. I would suggest to remove it and leave it up to the caller when to exit.

Use case:
<?php
ob_start();
$myQrCode->render();
$binaryImageData = ob_get_clean();
// Do some other stuff here ...
