### PR TITLE
Fix notices when array key does not exists

### DIFF
--- a/src/Endroid/QrCode/QrCode.php
+++ b/src/Endroid/QrCode/QrCode.php
@@ -556,7 +556,7 @@ class QrCode
 		        $i++;
 		    }
 		}
-		if (@$data_bits[$data_counter]>0) {
+		if (array_key_exists($data_counter,$data_bits) && $data_bits[$data_counter]>0) {
 		    $data_counter++;
 		}
 		$i=0;


### PR DESCRIPTION
Symfony error handler was catching Undefined offset: 51
