### PR TITLE
Improved padding behavior to preserve size

### DIFF
--- a/src/Endroid/QrCode/QrCode.php
+++ b/src/Endroid/QrCode/QrCode.php
@@ -1004,7 +1004,7 @@ class QrCode
         }
 
 
-		$output_image =imagecreate($this->size,$this->size);
+		$output_image =imagecreate($this->size + $this->padding * 2,$this->size + $this->padding * 2);
         imagecolorallocate($output_image, 255, 255, 255);
 
 		$image_path=$image_path."/qrv".$qrcode_version.".png";
@@ -1031,7 +1031,7 @@ class QrCode
 		    $ii++;
 		}
 
-		imagecopyresampled($output_image,$base_image,$this->padding,$this->padding,4,4,$this->size - $this->padding * 2,$this->size - $this->padding * 2,$mib - 8,$mib - 8);
+		imagecopyresampled($output_image,$base_image,$this->padding,$this->padding,4,4,$this->size,$this->size,$mib - 8,$mib - 8);
 
         if ($this->color_background != null) {
             $index = imagecolorclosest($output_image, 255, 255, 255);


### PR DESCRIPTION
I wanted a crisper appearance when adding padding, and I noticed that padding was subtracted from the image size. When the QRCode size is automatically determined the padding is not factored in, which means that the destination size for the code is `size - padding * 2`. And with a smaller destination area the code gets resampled. But by adding padding to the destination image size we can get a much sharper image by keeping the code's size the same.

Example with padding:

![test](https://cloud.githubusercontent.com/assets/58199/3456248/b08ee282-01ec-11e4-9394-7b8a9f159e93.png)

Illustration:

```
From (Size - Padding):

|----------- Size -----------|

+----------------------------+ —
|                            | | Padding
|  +----------------------+  | —
|  |                      |  | |
|  |                      |  | |
|  |                      |  | |
|  |                      |  | | Size - Padding
|  |                      |  | |
|  |                      |  | |
|  |                      |  | |
|  +----------------------+  | —
|                            |
+----------------------------+

To (Size + Padding):

+----------------------------+ —
|                            | | Padding
|  +----------------------+  | —
|  |                      |  | |
|  |                      |  | |
|  |                      |  | |
|  |                      |  | | Size
|  |                      |  | |
|  |                      |  | |
|  |                      |  | |
|  +----------------------+  | —
|                            |
+----------------------------+
```
