### PR TITLE
PHP 7.0 for WordPress compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /composer.lock
 /vendor/
+/nbproject/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 php:
+  - 7.0
   - 7.1
   - 7.2
   - nightly

--- a/src/QrCode.php
+++ b/src/QrCode.php
@@ -165,7 +165,7 @@ class QrCode implements QrCodeInterface
         $this->logoPath = $logoPath;
     }
 
-    public function getLogoPath(): ?string
+    public function getLogoPath()
     {
         return $this->logoPath;
     }
@@ -175,7 +175,7 @@ class QrCode implements QrCodeInterface
         $this->logoWidth = $logoWidth;
     }
 
-    public function getLogoWidth(): ?int
+    public function getLogoWidth()
     {
         return $this->logoWidth;
     }
@@ -201,7 +201,7 @@ class QrCode implements QrCodeInterface
         }
     }
 
-    public function getLabel(): ?string
+    public function getLabel()
     {
         return $this->label;
     }
@@ -211,7 +211,7 @@ class QrCode implements QrCodeInterface
         $this->labelFontSize = $labelFontSize;
     }
 
-    public function getLabelFontSize(): ?int
+    public function getLabelFontSize()
     {
         return $this->labelFontSize;
     }
@@ -227,7 +227,7 @@ class QrCode implements QrCodeInterface
         $this->labelFontPath = $labelFontPath;
     }
 
-    public function getLabelFontPath(): ?string
+    public function getLabelFontPath()
     {
         return $this->labelFontPath;
     }
@@ -237,7 +237,7 @@ class QrCode implements QrCodeInterface
         $this->labelAlignment = new LabelAlignment($labelAlignment);
     }
 
-    public function getLabelAlignment(): ?string
+    public function getLabelAlignment()
     {
         return $this->labelAlignment->getValue();
     }
@@ -247,7 +247,7 @@ class QrCode implements QrCodeInterface
         $this->labelMargin = array_merge($this->labelMargin, $labelMargin);
     }
 
-    public function getLabelMargin(): ?array
+    public function getLabelMargin()
     {
         return $this->labelMargin;
     }

--- a/src/QrCodeInterface.php
+++ b/src/QrCodeInterface.php
@@ -27,19 +27,19 @@ interface QrCodeInterface
 
     public function getErrorCorrectionLevel(): string;
 
-    public function getLogoPath(): ?string;
+    public function getLogoPath();
 
-    public function getLogoWidth(): ?int;
+    public function getLogoWidth();
 
-    public function getLabel(): ?string;
+    public function getLabel();
 
-    public function getLabelFontPath(): ?string;
+    public function getLabelFontPath();
 
-    public function getLabelFontSize(): ?int;
+    public function getLabelFontSize();
 
-    public function getLabelAlignment(): ?string;
+    public function getLabelAlignment();
 
-    public function getLabelMargin(): ?array;
+    public function getLabelMargin();
 
     public function getValidateResult(): bool;
 


### PR DESCRIPTION
The WP plugins directory software do not accept commits if the PHP code features used are above the 7.0 version.