### PR TITLE
fixed alpha not work

### DIFF
--- a/src/Writer/PngWriter.php
+++ b/src/Writer/PngWriter.php
@@ -80,7 +80,7 @@ class PngWriter extends AbstractWriter
         $backgroundColor = imagecolorallocatealpha($image, $qrCode->getBackgroundColor()['r'], $qrCode->getBackgroundColor()['g'], $qrCode->getBackgroundColor()['b'], $qrCode->getBackgroundColor()['a']);
         imagefill($image, 0, 0, $backgroundColor);
         imagecopyresampled($image, $baseImage, $data['margin_left'], $data['margin_left'], 0, 0, $data['inner_width'], $data['inner_height'], imagesx($baseImage), imagesy($baseImage));
-
+        imagesavealpha($image, true);
         return $image;
     }
 


### PR DESCRIPTION
Hi endroid: 

I want a qr code with alpha but not success when i use the writeFile to save a PNG qr code.
Then I found an example in the following page.
`http://php.net/manual/zh/function.imagefill.php` 

```
$new   = imagecreatetruecolor(320, 320);
$color = imagecolorallocatealpha($new, 0, 0, 0, 127);
imagefill($new, 0, 0, $color);
imagesavealpha($new, TRUE); // it took me a good 10 minutes to figure this part out
imagepng($new);
```
So, i try to edit the `createInterpolatedImage` function of `PngWriter` class, it looks like this
```
private function createInterpolatedImage($baseImage, array $data, QrCodeInterface $qrCode)
{
    $image = imagecreatetruecolor($data['outer_width'], $data['outer_height']);
    $backgroundColor = imagecolorallocatealpha($image, $qrCode->getBackgroundColor()['r'], $qrCode->getBackgroundColor()['g'], $qrCode->getBackgroundColor()['b'], $qrCode->getBackgroundColor()['a']);
    imagefill($image, 0, 0, $backgroundColor);
    imagecopyresampled($image, $baseImage, $data['margin_left'], $data['margin_left'], 0, 0, $data['inner_width'], $data['inner_height'], imagesx($baseImage), imagesy($baseImage));
    imagesavealpha($image, true);
    return $image;
}
```

then i got qr code with alpha, hope help you 