### PR TITLE
Move createWriterRegistry to constructor of QrCode

### DIFF
--- a/src/QrCode.php
+++ b/src/QrCode.php
@@ -69,6 +69,8 @@ class QrCode implements QrCodeInterface
 
         $this->errorCorrectionLevel = new ErrorCorrectionLevel(ErrorCorrectionLevel::LOW);
         $this->labelAlignment = new LabelAlignment(LabelAlignment::CENTER);
+
+        $this->createWriterRegistry();
     }
 
     public function setText(string $text): void
@@ -285,10 +287,6 @@ class QrCode implements QrCodeInterface
 
     public function getWriter(string $name = null): WriterInterface
     {
-        if (!$this->writerRegistry instanceof WriterRegistryInterface) {
-            $this->createWriterRegistry();
-        }
-
         if (!is_null($name)) {
             return $this->writerRegistry->getWriter($name);
         }

--- a/tests/QrCodeTest.php
+++ b/tests/QrCodeTest.php
@@ -57,35 +57,64 @@ class QrCodeTest extends TestCase
         $this->assertEquals('QR Code', $reader->text());
     }
 
-    public function testWriteQrCode(): void
+    /**
+     * @dataProvider writerNamesProvider
+     */
+    public function testWriteQrCodeByWriterName($writerName, $fileContent): void
     {
         $qrCode = new QrCode('QR Code');
         $qrCode->setLogoPath(__DIR__.'/../assets/images/symfony.png');
         $qrCode->setLogoWidth(100);
 
-        $qrCode->setWriterByName('binary');
-        $binData = $qrCode->writeString();
-        $this->assertTrue(is_string($binData));
+        $qrCode->setWriterByName($writerName);
+        $data = $qrCode->writeString();
+        $this->assertTrue(is_string($data));
 
-        $qrCode->setWriterByName('debug');
-        $debugData = $qrCode->writeString();
-        $this->assertTrue(is_string($debugData));
+        if (null !== $fileContent) {
+            $uriData = $qrCode->writeDataUri();
+            $this->assertTrue(0 === strpos($uriData, $fileContent));
+        }
+    }
 
-        $qrCode->setWriterByName('eps');
-        $epsData = $qrCode->writeString();
-        $this->assertTrue(is_string($epsData));
+    public function writerNamesProvider()
+    {
+        return [
+            ['binary', null],
+            ['debug', null],
+            ['eps', null],
+            ['png', 'data:image/png;base64'],
+            ['svg', 'data:image/svg+xml;base64']
+        ];
+    }
 
-        $qrCode->setWriterByName('png');
-        $pngData = $qrCode->writeString();
-        $this->assertTrue(is_string($pngData));
-        $pngDataUriData = $qrCode->writeDataUri();
-        $this->assertTrue(0 === strpos($pngDataUriData, 'data:image/png;base64'));
+    /**
+     * @dataProvider extensionsProvider
+     */
+    public function testWriteQrCodeByWriterExtension($extension, $fileContent): void
+    {
+        $qrCode = new QrCode('QR Code');
+        $qrCode->setLogoPath(__DIR__.'/../assets/images/symfony.png');
+        $qrCode->setLogoWidth(100);
 
-        $qrCode->setWriterByName('svg');
-        $svgData = $qrCode->writeString();
-        $this->assertTrue(is_string($svgData));
-        $svgDataUriData = $qrCode->writeDataUri();
-        $this->assertTrue(0 === strpos($svgDataUriData, 'data:image/svg+xml;base64'));
+        $qrCode->setWriterByExtension($extension);
+        $data = $qrCode->writeString();
+        $this->assertTrue(is_string($data));
+
+        if (null !== $fileContent) {
+            $uriData = $qrCode->writeDataUri();
+            $this->assertTrue(0 === strpos($uriData, $fileContent));
+        }
+    }
+
+    public function extensionsProvider()
+    {
+        return [
+            ['bin', null],
+            ['txt', null],
+            ['eps', null],
+            ['png', 'data:image/png;base64'],
+            ['svg', 'data:image/svg+xml;base64']
+        ];
     }
 
     public function testSetSize(): void


### PR DESCRIPTION
`$qrCode->setWriterByExtension()` does not work (fails with `Call to a member function getWriters() on null`) unless the `writerRegistry` is created first.

Based on the other usage within the class, I'd say the corresponding call could be moved to the constructor.

This pr changes this behaviour and provides tests (which fail on current master).