### PR TITLE
Add enum method hints to enable static analysis

### DIFF
--- a/src/ErrorCorrectionLevel.php
+++ b/src/ErrorCorrectionLevel.php
@@ -14,6 +14,12 @@ namespace Endroid\QrCode;
 use MyCLabs\Enum\Enum;
 use BaconQrCode\Common\ErrorCorrectionLevel as BaconErrorCorrectionLevel;
 
+/**
+ * @method static ErrorCorrectionLevel LOW()
+ * @method static ErrorCorrectionLevel MEDIUM()
+ * @method static ErrorCorrectionLevel QUARTILE()
+ * @method static ErrorCorrectionLevel HIGH()
+ */
 class ErrorCorrectionLevel extends Enum
 {
     const LOW = 'low';

--- a/src/LabelAlignment.php
+++ b/src/LabelAlignment.php
@@ -13,6 +13,11 @@ namespace Endroid\QrCode;
 
 use MyCLabs\Enum\Enum;
 
+/**
+ * @method static LabelAlignment LEFT()
+ * @method static LabelAlignment CENTER()
+ * @method static LabelAlignment RIGHT()
+ */
 class LabelAlignment extends Enum
 {
     const LEFT = 'left';


### PR DESCRIPTION
This adds method hints for enums to allow static code analysis or inspection to work properly.

Thanks