### PR TITLE
Feature/color handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /composer.lock
 /vendor/
+.idea

--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ echo $qrCode->writeString();
 ## Advanced usage
 
 ```php
+<?php 
+
+use Color\Value\RGB;
 use Endroid\QrCode\ErrorCorrectionLevel;
 use Endroid\QrCode\LabelAlignment;
 use Endroid\QrCode\QrCode;
@@ -49,8 +52,8 @@ $qrCode->setWriterByName('png');
 $qrCode->setMargin(10);
 $qrCode->setEncoding('UTF-8');
 $qrCode->setErrorCorrectionLevel(new ErrorCorrectionLevel(ErrorCorrectionLevel::HIGH));
-$qrCode->setForegroundColor(['r' => 0, 'g' => 0, 'b' => 0, 'a' => 0]);
-$qrCode->setBackgroundColor(['r' => 255, 'g' => 255, 'b' => 255, 'a' => 0]);
+$qrCode->setForegroundColor(new RGB(0, 0, 0));
+$qrCode->setBackgroundColor(new RGB(255, 255, 255));
 $qrCode->setLabel('Scan the code', 16, __DIR__.'/../assets/fonts/noto_sans.otf', LabelAlignment::CENTER);
 $qrCode->setLogoPath(__DIR__.'/../assets/images/symfony.png');
 $qrCode->setLogoSize(150, 200);

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,9 @@
     ],
     "require": {
         "php": ">=7.2",
+        "ext-fileinfo": "*",
         "ext-gd": "*",
+        "ext-simplexml": "*",
         "bacon/bacon-qr-code": "^2.0",
         "bitandblack/colors": "^2.4",
         "endroid/installer": "^1.1.5",
@@ -33,6 +35,9 @@
     "require-dev": {
         "endroid/test": "^1.1.4",
         "phpunit/phpunit": "^8.2"
+    },
+    "config": {
+        "sort-packages": true
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
     },
     "require-dev": {
         "endroid/test": "^1.1.4",
+        "phpstan/phpstan": "^0.11.12",
         "phpunit/phpunit": "^8.2"
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,16 @@
 {
     "name": "endroid/qr-code",
-    "description": "Endroid QR Code",
-    "keywords": ["endroid", "qrcode", "qr", "code", "bundle", "php"],
-    "homepage": "https://github.com/endroid/qr-code",
     "type": "library",
+    "description": "Endroid QR Code",
+    "keywords": [
+        "endroid",
+        "qrcode",
+        "qr",
+        "code",
+        "bundle",
+        "php"
+    ],
+    "homepage": "https://github.com/endroid/qr-code",
     "license": "MIT",
     "authors": [
         {
@@ -15,15 +22,22 @@
         "php": ">=7.2",
         "ext-gd": "*",
         "bacon/bacon-qr-code": "^2.0",
+        "bitandblack/colors": "^2.4",
         "endroid/installer": "^1.1.5",
         "khanamiryan/qrcode-detector-decoder": "^1.0.2",
         "myclabs/php-enum": "^1.5",
-        "symfony/http-foundation": "^3.4|^4.0",
-        "symfony/options-resolver": "^3.4|^4.0",
-        "symfony/property-access": "^3.4|^4.0"
+        "symfony/http-foundation": "^3.4 || ^4.0",
+        "symfony/options-resolver": "^3.4 || ^4.0",
+        "symfony/property-access": "^3.4 || ^4.0"
     },
     "require-dev": {
-        "endroid/test": "^1.1.4"
+        "endroid/test": "^1.1.4",
+        "phpunit/phpunit": "^8.2"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "3.x-dev"
+        }
     },
     "autoload": {
         "psr-4": {
@@ -33,11 +47,6 @@
     "autoload-dev": {
         "psr-4": {
             "Endroid\\QrCode\\Tests\\": "tests/"
-        }
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "3.x-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "ext-gd": "*",
         "ext-simplexml": "*",
         "bacon/bacon-qr-code": "^2.0",
-        "bitandblack/colors": "^2.4",
+        "bitandblack/colors": "^2.4.1",
         "endroid/installer": "^1.1.5",
         "khanamiryan/qrcode-detector-decoder": "^1.0.2",
         "myclabs/php-enum": "^1.5",

--- a/src/Factory/QrCodeFactoryInterface.php
+++ b/src/Factory/QrCodeFactoryInterface.php
@@ -15,5 +15,5 @@ use Endroid\QrCode\QrCodeInterface;
 
 interface QrCodeFactoryInterface
 {
-    public function create(string $text = '', array $options = []): QrCodeInterface;
+    public function create(string $text, array $options = []): QrCodeInterface;
 }

--- a/src/QrCode.php
+++ b/src/QrCode.php
@@ -70,8 +70,8 @@ class QrCode implements QrCodeInterface
 
         $this->createWriterRegistry();
 
-        $this->foregroundColor = new RGBA(255, 255, 255, 1);
-        $this->backgroundColor = new RGBA(0, 0, 0, 1);
+        $this->backgroundColor = new RGBA(255, 255, 255, 1);
+        $this->foregroundColor = new RGBA(0, 0, 0, 1);
     }
 
     public function setText(string $text): void

--- a/src/QrCode.php
+++ b/src/QrCode.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 namespace Endroid\QrCode;
 
 use BaconQrCode\Encoder\Encoder;
+use Color\Value\RGBA;
+use Color\Value\ValueInterface;
 use Endroid\QrCode\Exception\InvalidPathException;
 use Endroid\QrCode\Exception\UnsupportedExtensionException;
 use Endroid\QrCode\Writer\WriterInterface;
@@ -25,19 +27,15 @@ class QrCode implements QrCodeInterface
     private $size = 300;
     private $margin = 10;
 
-    private $foregroundColor = [
-        'r' => 0,
-        'g' => 0,
-        'b' => 0,
-        'a' => 0,
-    ];
+    /**
+     * @var \Color\Value\ValueInterface 
+     */
+    private $foregroundColor;
 
-    private $backgroundColor = [
-        'r' => 255,
-        'g' => 255,
-        'b' => 255,
-        'a' => 0,
-    ];
+    /**
+     * @var \Color\Value\ValueInterface
+     */
+    private $backgroundColor;
 
     private $encoding = 'UTF-8';
     private $roundBlockSize = true;
@@ -71,6 +69,9 @@ class QrCode implements QrCodeInterface
         $this->labelAlignment = new LabelAlignment(LabelAlignment::CENTER);
 
         $this->createWriterRegistry();
+
+        $this->foregroundColor = new RGBA(255, 255, 255, 1);
+        $this->backgroundColor = new RGBA(0, 0, 0, 1);
     }
 
     public function setText(string $text): void
@@ -103,38 +104,38 @@ class QrCode implements QrCodeInterface
         return $this->margin;
     }
 
-    public function setForegroundColor(array $foregroundColor): void
+    /**
+     * @param \Color\Value\ValueInterface $foregroundColor
+     * @return \Endroid\QrCode\QrCode
+     */
+    public function setForegroundColor(ValueInterface $foregroundColor): self
     {
-        if (!isset($foregroundColor['a'])) {
-            $foregroundColor['a'] = 0;
-        }
-
-        foreach ($foregroundColor as &$color) {
-            $color = intval($color);
-        }
-
         $this->foregroundColor = $foregroundColor;
+        return $this;
     }
 
-    public function getForegroundColor(): array
+    /**
+     * @return \Color\Value\ValueInterface
+     */
+    public function getForegroundColor(): ValueInterface
     {
         return $this->foregroundColor;
     }
 
-    public function setBackgroundColor(array $backgroundColor): void
+    /**
+     * @param \Color\Value\ValueInterface $backgroundColor
+     * @return \Endroid\QrCode\QrCode
+     */
+    public function setBackgroundColor(ValueInterface $backgroundColor): self
     {
-        if (!isset($backgroundColor['a'])) {
-            $backgroundColor['a'] = 0;
-        }
-
-        foreach ($backgroundColor as &$color) {
-            $color = intval($color);
-        }
-
         $this->backgroundColor = $backgroundColor;
+        return $this;
     }
 
-    public function getBackgroundColor(): array
+    /**
+     * @return \Color\Value\ValueInterface
+     */
+    public function getBackgroundColor(): ValueInterface
     {
         return $this->backgroundColor;
     }

--- a/src/QrCode.php
+++ b/src/QrCode.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace Endroid\QrCode;
 
 use BaconQrCode\Encoder\Encoder;
-use Color\Value\RGBA;
+use Color\Value\RGB;
 use Color\Value\ValueInterface;
 use Endroid\QrCode\Exception\InvalidPathException;
 use Endroid\QrCode\Exception\UnsupportedExtensionException;
@@ -70,8 +70,8 @@ class QrCode implements QrCodeInterface
 
         $this->createWriterRegistry();
 
-        $this->backgroundColor = new RGBA(255, 255, 255, 1);
-        $this->foregroundColor = new RGBA(0, 0, 0, 1);
+        $this->backgroundColor = new RGB(255, 255, 255);
+        $this->foregroundColor = new RGB(0, 0, 0);
     }
 
     public function setText(string $text): void

--- a/src/QrCodeInterface.php
+++ b/src/QrCodeInterface.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
 
 namespace Endroid\QrCode;
 
+use Color\Value\ValueInterface;
+
 interface QrCodeInterface
 {
     public function getText(): string;
@@ -19,9 +21,19 @@ interface QrCodeInterface
 
     public function getMargin(): int;
 
-    public function getForegroundColor(): array;
+    /**
+     * Returns the foreground color
+     * 
+     * @return \Color\Value\ValueInterface
+     */
+    public function getForegroundColor(): ValueInterface;
 
-    public function getBackgroundColor(): array;
+    /**
+     * Returns the background color
+     *
+     * @return \Color\Value\ValueInterface
+     */
+    public function getBackgroundColor(): ValueInterface;
 
     public function getEncoding(): string;
 

--- a/src/Writer/EpsWriter.php
+++ b/src/Writer/EpsWriter.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
 
 namespace Endroid\QrCode\Writer;
 
+use Color\Value\CMYK;
+use Color\Value\RGB;
 use Endroid\QrCode\QrCodeInterface;
 
 class EpsWriter extends AbstractWriter
@@ -19,13 +21,43 @@ class EpsWriter extends AbstractWriter
     {
         $data = $qrCode->getData();
 
+        switch ($qrCode->getBackgroundColor())
+        {
+            case RGB::class:
+                $backgroundColor = $qrCode->getBackgroundColor()->getFormattedValue('%d %d %d').' setrgbcolor';
+                break;
+
+            case CMYK::class:
+                $backgroundColor = $qrCode->getBackgroundColor()->getFormattedValue('%d %d %d %d').' setcmykcolor';
+                break;
+
+            default:
+                $backgroundColor = '';
+                break;
+        }
+        
+        switch ($qrCode->getForegroundColor())
+        {
+            case RGB::class:
+                $foregroundColor = $qrCode->getForegroundColor()->getFormattedValue('%d %d %d').' setrgbcolor';
+                break;
+
+            case CMYK::class:
+                $foregroundColor = $qrCode->getForegroundColor()->getFormattedValue('%d %d %d %d').' setcmykcolor';
+                break;
+
+            default:
+                $foregroundColor = '';
+                break;
+        }
+        
         $epsData = [];
         $epsData[] = '%!PS-Adobe-3.0 EPSF-3.0';
         $epsData[] = '%%BoundingBox: 0 0 '.$data['outer_width'].' '.$data['outer_height'];
         $epsData[] = '/F { rectfill } def';
-        $epsData[] = number_format($qrCode->getBackgroundColor()['r'] / 100, 2, '.', ',').' '.number_format($qrCode->getBackgroundColor()['g'] / 100, 2, '.', ',').' '.number_format($qrCode->getBackgroundColor()['b'] / 100, 2, '.', ',').' setrgbcolor';
+        $epsData[] = $backgroundColor;
         $epsData[] = '0 0 '.$data['outer_width'].' '.$data['outer_height'].' F';
-        $epsData[] = number_format($qrCode->getForegroundColor()['r'] / 100, 2, '.', ',').' '.number_format($qrCode->getForegroundColor()['g'] / 100, 2, '.', ',').' '.number_format($qrCode->getForegroundColor()['b'] / 100, 2, '.', ',').' setrgbcolor';
+        $epsData[] = $foregroundColor;
 
         foreach ($data['matrix'] as $row => $values) {
             foreach ($values as $column => $value) {

--- a/src/Writer/EpsWriter.php
+++ b/src/Writer/EpsWriter.php
@@ -11,8 +11,8 @@ declare(strict_types=1);
 
 namespace Endroid\QrCode\Writer;
 
+use Color\Value\CMY;
 use Color\Value\CMYK;
-use Color\Value\RGB;
 use Endroid\QrCode\QrCodeInterface;
 
 class EpsWriter extends AbstractWriter
@@ -21,34 +21,20 @@ class EpsWriter extends AbstractWriter
     {
         $data = $qrCode->getData();
 
-        switch ($qrCode->getBackgroundColor())
-        {
-            case RGB::class:
-                $backgroundColor = $qrCode->getBackgroundColor()->getFormattedValue('%d %d %d').' setrgbcolor';
-                break;
+        $backgroundColor = $qrCode->getBackgroundColor()->getRGB()->getFormattedValue('%d %d %d').' setrgbcolor';
 
-            case CMYK::class:
-                $backgroundColor = $qrCode->getBackgroundColor()->getFormattedValue('%d %d %d %d').' setcmykcolor';
-                break;
-
-            default:
-                $backgroundColor = '';
-                break;
+        if ($qrCode->getBackgroundColor() instanceof CMYK
+            || $qrCode->getBackgroundColor() instanceof CMY
+        ) {
+            $backgroundColor = $qrCode->getBackgroundColor()->getCMYK()->getFormattedValue('%d %d %d %d').' setcmykcolor';
         }
-        
-        switch ($qrCode->getForegroundColor())
-        {
-            case RGB::class:
-                $foregroundColor = $qrCode->getForegroundColor()->getFormattedValue('%d %d %d').' setrgbcolor';
-                break;
 
-            case CMYK::class:
-                $foregroundColor = $qrCode->getForegroundColor()->getFormattedValue('%d %d %d %d').' setcmykcolor';
-                break;
+        $foregroundColor = $qrCode->getForegroundColor()->getRGB()->getFormattedValue('%d %d %d').' setrgbcolor';
 
-            default:
-                $foregroundColor = '';
-                break;
+        if ($qrCode->getForegroundColor() instanceof CMYK
+            || $qrCode->getForegroundColor() instanceof CMY
+        ) {
+            $foregroundColor = $qrCode->getForegroundColor()->getCMYK()->getFormattedValue('%d %d %d %d').' setcmykcolor';
         }
         
         $epsData = [];

--- a/src/Writer/PngWriter.php
+++ b/src/Writer/PngWriter.php
@@ -68,17 +68,17 @@ class PngWriter extends AbstractWriter
 
         $foregroundColor = imagecolorallocatealpha(
             $image, 
-            $qrCode->getForegroundColor()->getValue('R'), 
-            $qrCode->getForegroundColor()->getValue('G'), 
-            $qrCode->getForegroundColor()->getValue('B'), 
-            $qrCode->getForegroundColor()->getValue('A')
+            $qrCode->getForegroundColor()->getRGBA()->getValue('R'), 
+            $qrCode->getForegroundColor()->getRGBA()->getValue('G'), 
+            $qrCode->getForegroundColor()->getRGBA()->getValue('B'), 
+            $qrCode->getForegroundColor()->getRGBA()->getValue('A')
         );
         $backgroundColor = imagecolorallocatealpha(
             $image, 
-            $qrCode->getBackgroundColor()->getValue('R'), 
-            $qrCode->getBackgroundColor()->getValue('G'), 
-            $qrCode->getBackgroundColor()->getValue('B'), 
-            $qrCode->getBackgroundColor()->getValue('A')
+            $qrCode->getBackgroundColor()->getRGBA()->getValue('R'), 
+            $qrCode->getBackgroundColor()->getRGBA()->getValue('G'), 
+            $qrCode->getBackgroundColor()->getRGBA()->getValue('B'), 
+            $qrCode->getBackgroundColor()->getRGBA()->getValue('A')
         );
         imagefill($image, 0, 0, $backgroundColor);
 

--- a/src/Writer/PngWriter.php
+++ b/src/Writer/PngWriter.php
@@ -103,10 +103,10 @@ class PngWriter extends AbstractWriter
 
         $backgroundColor = imagecolorallocatealpha(
             $image, 
-            $qrCode->getBackgroundColor()->getValue('R'), 
-            $qrCode->getBackgroundColor()->getValue('G'), 
-            $qrCode->getBackgroundColor()->getValue('B'), 
-            $qrCode->getBackgroundColor()->getValue('A')
+            $qrCode->getBackgroundColor()->getRGBA()->getValue('R'), 
+            $qrCode->getBackgroundColor()->getRGBA()->getValue('G'), 
+            $qrCode->getBackgroundColor()->getRGBA()->getValue('B'), 
+            $qrCode->getBackgroundColor()->getRGBA()->getValue('A')
         );
         imagefill($image, 0, 0, $backgroundColor);
         imagecopyresampled($image, $baseImage, (int) $data['margin_left'], (int) $data['margin_left'], 0, 0, (int) $data['inner_width'], (int) $data['inner_height'], imagesx($baseImage), imagesy($baseImage));

--- a/src/Writer/PngWriter.php
+++ b/src/Writer/PngWriter.php
@@ -19,6 +19,14 @@ use Endroid\QrCode\LabelAlignment;
 use Endroid\QrCode\QrCodeInterface;
 use Zxing\QrReader;
 
+/**
+ * Class PngWriter
+ * Outputs the QR as PNG. 
+ * Note that colors with alpha channels like RGBA will not affect the transparency of the image.
+ * The alpha information is getting used for creating the color. For example rgba(255, 255, 255, .5) will return grey.
+ * 
+ * @package Endroid\QrCode\Writer
+ */
 class PngWriter extends AbstractWriter
 {
     public function writeString(QrCodeInterface $qrCode): string
@@ -68,18 +76,20 @@ class PngWriter extends AbstractWriter
 
         $foregroundColor = imagecolorallocatealpha(
             $image, 
-            $qrCode->getForegroundColor()->getRGBA()->getValue('R'), 
-            $qrCode->getForegroundColor()->getRGBA()->getValue('G'), 
-            $qrCode->getForegroundColor()->getRGBA()->getValue('B'), 
-            $qrCode->getForegroundColor()->getRGBA()->getValue('A')
+            $qrCode->getForegroundColor()->getRGB()->getValue('R'), 
+            $qrCode->getForegroundColor()->getRGB()->getValue('G'), 
+            $qrCode->getForegroundColor()->getRGB()->getValue('B'),
+            0
         );
+        
         $backgroundColor = imagecolorallocatealpha(
             $image, 
-            $qrCode->getBackgroundColor()->getRGBA()->getValue('R'), 
-            $qrCode->getBackgroundColor()->getRGBA()->getValue('G'), 
-            $qrCode->getBackgroundColor()->getRGBA()->getValue('B'), 
-            $qrCode->getBackgroundColor()->getRGBA()->getValue('A')
+            $qrCode->getBackgroundColor()->getRGB()->getValue('R'), 
+            $qrCode->getBackgroundColor()->getRGB()->getValue('G'), 
+            $qrCode->getBackgroundColor()->getRGB()->getValue('B'),
+            0
         );
+
         imagefill($image, 0, 0, $backgroundColor);
 
         foreach ($data['matrix'] as $row => $values) {
@@ -103,14 +113,14 @@ class PngWriter extends AbstractWriter
 
         $backgroundColor = imagecolorallocatealpha(
             $image, 
-            $qrCode->getBackgroundColor()->getRGBA()->getValue('R'), 
-            $qrCode->getBackgroundColor()->getRGBA()->getValue('G'), 
-            $qrCode->getBackgroundColor()->getRGBA()->getValue('B'), 
-            $qrCode->getBackgroundColor()->getRGBA()->getValue('A')
+            $qrCode->getBackgroundColor()->getRGB()->getValue('R'), 
+            $qrCode->getBackgroundColor()->getRGB()->getValue('G'), 
+            $qrCode->getBackgroundColor()->getRGB()->getValue('B'),
+            0
         );
+        
         imagefill($image, 0, 0, $backgroundColor);
         imagecopyresampled($image, $baseImage, (int) $data['margin_left'], (int) $data['margin_left'], 0, 0, (int) $data['inner_width'], (int) $data['inner_height'], imagesx($baseImage), imagesy($baseImage));
-        imagesavealpha($image, true);
 
         return $image;
     }

--- a/src/Writer/PngWriter.php
+++ b/src/Writer/PngWriter.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Endroid\QrCode\Writer;
 
+use Color\Value\ValueInterface;
 use Endroid\QrCode\Exception\GenerateImageException;
 use Endroid\QrCode\Exception\MissingFunctionException;
 use Endroid\QrCode\Exception\ValidationException;
@@ -65,8 +66,20 @@ class PngWriter extends AbstractWriter
             throw new GenerateImageException('Unable to generate image: check your GD installation');
         }
 
-        $foregroundColor = imagecolorallocatealpha($image, $qrCode->getForegroundColor()['r'], $qrCode->getForegroundColor()['g'], $qrCode->getForegroundColor()['b'], $qrCode->getForegroundColor()['a']);
-        $backgroundColor = imagecolorallocatealpha($image, $qrCode->getBackgroundColor()['r'], $qrCode->getBackgroundColor()['g'], $qrCode->getBackgroundColor()['b'], $qrCode->getBackgroundColor()['a']);
+        $foregroundColor = imagecolorallocatealpha(
+            $image, 
+            $qrCode->getForegroundColor()->getValue('R'), 
+            $qrCode->getForegroundColor()->getValue('G'), 
+            $qrCode->getForegroundColor()->getValue('B'), 
+            $qrCode->getForegroundColor()->getValue('A')
+        );
+        $backgroundColor = imagecolorallocatealpha(
+            $image, 
+            $qrCode->getBackgroundColor()->getValue('R'), 
+            $qrCode->getBackgroundColor()->getValue('G'), 
+            $qrCode->getBackgroundColor()->getValue('B'), 
+            $qrCode->getBackgroundColor()->getValue('A')
+        );
         imagefill($image, 0, 0, $backgroundColor);
 
         foreach ($data['matrix'] as $row => $values) {
@@ -88,7 +101,13 @@ class PngWriter extends AbstractWriter
             throw new GenerateImageException('Unable to generate image: check your GD installation');
         }
 
-        $backgroundColor = imagecolorallocatealpha($image, $qrCode->getBackgroundColor()['r'], $qrCode->getBackgroundColor()['g'], $qrCode->getBackgroundColor()['b'], $qrCode->getBackgroundColor()['a']);
+        $backgroundColor = imagecolorallocatealpha(
+            $image, 
+            $qrCode->getBackgroundColor()->getValue('R'), 
+            $qrCode->getBackgroundColor()->getValue('G'), 
+            $qrCode->getBackgroundColor()->getValue('B'), 
+            $qrCode->getBackgroundColor()->getValue('A')
+        );
         imagefill($image, 0, 0, $backgroundColor);
         imagecopyresampled($image, $baseImage, (int) $data['margin_left'], (int) $data['margin_left'], 0, 0, (int) $data['inner_width'], (int) $data['inner_height'], imagesx($baseImage), imagesy($baseImage));
         imagesavealpha($image, true);
@@ -124,8 +143,29 @@ class PngWriter extends AbstractWriter
         return $sourceImage;
     }
 
-    private function addLabel($sourceImage, string $label, string $labelFontPath, int $labelFontSize, string $labelAlignment, array $labelMargin, array $foregroundColor, array $backgroundColor)
-    {
+    /**
+     * @param $sourceImage
+     * @param string $label
+     * @param string $labelFontPath
+     * @param int $labelFontSize
+     * @param string $labelAlignment
+     * @param array $labelMargin
+     * @param \Color\Value\ValueInterface $foregroundColor
+     * @param \Color\Value\ValueInterface $backgroundColor
+     * @return false|resource
+     * @throws \Endroid\QrCode\Exception\GenerateImageException
+     * @throws \Endroid\QrCode\Exception\MissingFunctionException
+     */
+    private function addLabel(
+        $sourceImage, 
+        string $label, 
+        string $labelFontPath, 
+        int $labelFontSize, 
+        string $labelAlignment, 
+        array $labelMargin, 
+        ValueInterface $foregroundColor, 
+        ValueInterface $backgroundColor
+    ) {
         if (!function_exists('imagettfbbox')) {
             throw new MissingFunctionException('Missing function "imagettfbbox", please make sure you installed the FreeType library');
         }
@@ -146,8 +186,18 @@ class PngWriter extends AbstractWriter
             throw new GenerateImageException('Unable to generate image: check your GD installation');
         }
 
-        $foregroundColor = imagecolorallocate($targetImage, $foregroundColor['r'], $foregroundColor['g'], $foregroundColor['b']);
-        $backgroundColor = imagecolorallocate($targetImage, $backgroundColor['r'], $backgroundColor['g'], $backgroundColor['b']);
+        $foregroundColor = imagecolorallocate(
+            $targetImage, 
+            $foregroundColor->getRGB()->getValue('R'), 
+            $foregroundColor->getRGB()->getValue('G'), 
+            $foregroundColor->getRGB()->getValue('B')
+        );
+        $backgroundColor = imagecolorallocate(
+            $targetImage, 
+            $backgroundColor->getRGB()->getValue('R'), 
+            $backgroundColor->getRGB()->getValue('G'), 
+            $backgroundColor->getRGB()->getValue('B')
+        );
         imagefill($targetImage, 0, 0, $backgroundColor);
 
         // Copy source image to target image

--- a/src/Writer/PngWriter.php
+++ b/src/Writer/PngWriter.php
@@ -154,7 +154,7 @@ class PngWriter extends AbstractWriter
     }
 
     /**
-     * @param $sourceImage
+     * @param resource $sourceImage
      * @param string $label
      * @param string $labelFontPath
      * @param int $labelFontSize
@@ -162,7 +162,7 @@ class PngWriter extends AbstractWriter
      * @param array $labelMargin
      * @param \Color\Value\ValueInterface $foregroundColor
      * @param \Color\Value\ValueInterface $backgroundColor
-     * @return false|resource
+     * @return resource
      * @throws \Endroid\QrCode\Exception\GenerateImageException
      * @throws \Endroid\QrCode\Exception\MissingFunctionException
      */

--- a/src/Writer/SvgWriter.php
+++ b/src/Writer/SvgWriter.php
@@ -41,8 +41,7 @@ class SvgWriter extends AbstractWriter
         $blockDefinition->addAttribute('id', 'block');
         $blockDefinition->addAttribute('width', strval($data['block_size']));
         $blockDefinition->addAttribute('height', strval($data['block_size']));
-        $blockDefinition->addAttribute('fill', '#'.sprintf('%02x%02x%02x', $qrCode->getForegroundColor()['r'], $qrCode->getForegroundColor()['g'], $qrCode->getForegroundColor()['b']));
-        $blockDefinition->addAttribute('fill-opacity', strval($this->getOpacity($qrCode->getForegroundColor()['a'])));
+        $blockDefinition->addAttribute('fill', (string) $qrCode->getForegroundColor()->getHEX());
 
         // Background
         $background = $svg->addChild('rect');
@@ -50,8 +49,7 @@ class SvgWriter extends AbstractWriter
         $background->addAttribute('y', '0');
         $background->addAttribute('width', strval($data['outer_width']));
         $background->addAttribute('height', strval($data['outer_height']));
-        $background->addAttribute('fill', '#'.sprintf('%02x%02x%02x', $qrCode->getBackgroundColor()['r'], $qrCode->getBackgroundColor()['g'], $qrCode->getBackgroundColor()['b']));
-        $background->addAttribute('fill-opacity', strval($this->getOpacity($qrCode->getBackgroundColor()['a'])));
+        $background->addAttribute('fill', (string) $qrCode->getBackgroundColor()->getHEX());
 
         foreach ($data['matrix'] as $row => $values) {
             foreach ($values as $column => $value) {
@@ -133,13 +131,6 @@ class SvgWriter extends AbstractWriter
         }
 
         return $mimeType;
-    }
-
-    private function getOpacity(int $alpha): float
-    {
-        $opacity = 1 - $alpha / 127;
-
-        return $opacity;
     }
 
     public static function getContentType(): string

--- a/tests/Writer/EpsWriterTest.php
+++ b/tests/Writer/EpsWriterTest.php
@@ -23,15 +23,14 @@ class EpsWriterTest extends TestCase
         $backgroundColor = [0, 4, 4];
         $foregroundColor = [0, 255, 200];
 
+        $backgroundColorRGB = new RGB(...$backgroundColor);
+        $foregroundColorRGB = new RGB(...$foregroundColor);         
+
         $qrCode = new QrCode();
         $qrCode->setWriter(new EpsWriter());
         $qrCode
-            ->setBackgroundColor(
-                new RGB(...$backgroundColor)
-            )
-            ->setForegroundColor(
-                new RGB(...$foregroundColor)
-            )
+            ->setBackgroundColor($backgroundColorRGB)
+            ->setForegroundColor($foregroundColorRGB)
         ;
 
         $string = $qrCode->writeString();

--- a/tests/Writer/EpsWriterTest.php
+++ b/tests/Writer/EpsWriterTest.php
@@ -61,15 +61,14 @@ class EpsWriterTest extends TestCase
         $backgroundColor = [0, 5, 5, 0];
         $foregroundColor = [0, 100, 100, 0];
 
+        $backgroundColorCMYK = new CMYK(...$backgroundColor);
+        $foregroundColorCMYK = new CMYK(...$foregroundColor);
+
         $qrCode = new QrCode();
         $qrCode->setWriter(new EpsWriter());
         $qrCode
-            ->setBackgroundColor(
-                new CMYK(...$backgroundColor)
-            )
-            ->setForegroundColor(
-                new CMYK(...$foregroundColor)
-            )
+            ->setBackgroundColor($backgroundColorCMYK)
+            ->setForegroundColor($foregroundColorCMYK)
         ;
 
         $string = $qrCode->writeString();

--- a/tests/Writer/EpsWriterTest.php
+++ b/tests/Writer/EpsWriterTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Endroid\QrCode\Tests\Writer;
+
+use Color\Value\CMYK;
+use Color\Value\RGB;
+use Endroid\QrCode\QrCode;
+use Endroid\QrCode\Writer\EpsWriter;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class EpsWriterTest
+ * 
+ * @package Endroid\QrCode\Tests\Writer
+ */
+class EpsWriterTest extends TestCase
+{
+    /**
+     * Tests if RGB colors can be added successfully
+     */
+    public function testCanHandleRGBColors()
+    {
+        $backgroundColor = [0, 4, 4];
+        $foregroundColor = [0, 255, 200];
+
+        $qrCode = new QrCode();
+        $qrCode->setWriter(new EpsWriter());
+        $qrCode
+            ->setBackgroundColor(
+                new RGB(...$backgroundColor)
+            )
+            ->setForegroundColor(
+                new RGB(...$foregroundColor)
+            )
+        ;
+
+        $string = $qrCode->writeString();
+        $colorLines = [];
+
+        foreach (preg_split("/((\r?\n)|(\r\n?))/", $string) as $line){
+            if (strpos($line, 'setrgbcolor') !== false) {
+                $colorLines[] = $line;
+            }
+        }
+
+        $this->assertEquals(
+            $colorLines[0] ?? '',
+            implode(' ', $backgroundColor).' setrgbcolor'
+        );
+
+        $this->assertEquals(
+            $colorLines[1] ?? '',
+            implode(' ', $foregroundColor).' setrgbcolor'
+        );
+    }
+    
+    /**
+     * Tests if CMYK colors can be added successfully
+     */
+    public function testCanHandleCMYKColors()
+    {
+        $backgroundColor = [0, 5, 5, 0];
+        $foregroundColor = [0, 100, 100, 0];
+
+        $qrCode = new QrCode();
+        $qrCode->setWriter(new EpsWriter());
+        $qrCode
+            ->setBackgroundColor(
+                new CMYK(...$backgroundColor)
+            )
+            ->setForegroundColor(
+                new CMYK(...$foregroundColor)
+            )
+        ;
+
+        $string = $qrCode->writeString();
+        $colorLines = [];
+
+        foreach (preg_split("/((\r?\n)|(\r\n?))/", $string) as $line){
+            if (strpos($line, 'setcmykcolor') !== false) {
+                $colorLines[] = $line;
+            }
+        }
+
+        $this->assertEquals(
+            $colorLines[0],
+            implode(' ', $backgroundColor).' setcmykcolor'
+        );
+
+        $this->assertEquals(
+            $colorLines[1],
+            implode(' ', $foregroundColor).' setcmykcolor'
+        );
+    }
+}

--- a/tests/Writer/SvgWriterTest.php
+++ b/tests/Writer/SvgWriterTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Endroid\QrCode\Tests\Writer;
+
+use Color\Value\RGB;
+use Endroid\QrCode\QrCode;
+use Endroid\QrCode\Writer\SvgWriter;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class SvgWriterTest
+ * 
+ * @package Endroid\QrCode\Tests\Writer
+ */
+class SvgWriterTest extends TestCase
+{
+    /**
+     * Tests if HEX colors can be added successfully
+     */
+    public function testCanHandleHEXColors()
+    {
+        $backgroundColor = [0, 4, 4];
+        $foregroundColor = [0, 255, 200];
+
+        $backgroundColorRGB = new RGB(...$backgroundColor);
+        $foregroundColorRGB = new RGB(...$foregroundColor);
+        
+        $qrCode = new QrCode();
+        $qrCode->setWriter(new SvgWriter());
+        $qrCode
+            ->setBackgroundColor($backgroundColorRGB)
+            ->setForegroundColor($foregroundColorRGB)
+        ;
+
+        $string = $qrCode->writeString();
+
+        $this->assertNotFalse(
+            strpos($string, 'fill="'.$foregroundColorRGB->getHEX().'"'),
+            'No hex color found'
+        );
+
+        $this->assertNotFalse(
+            strpos($string, 'fill="'.$backgroundColorRGB->getHEX().'"'),
+            'No hex color found'
+        );
+    }
+}


### PR DESCRIPTION
**This pull request wants to improve the color handling.** It will make use of the [bitandblack/colors](https://packagist.org/packages/bitandblack/colors) library which provides a lot of color informations and a logic to convert colors in different color spaces. 
By using this library, endoird/qr-code is able to handle different color spaces now. To be exact: I can create EPS files in RGB and also CMYK. 
There a still some things open: 
* It's hard to add PANTONE and HKS colors into EPS files. This is not possible at the moment (and I don't even know how to do that...) but it would be important for some people.
* Writers that will be added in the future—maybe a TIF or a JPEG writer—will also be able to use different color spaces. Those writers don't exist at the moment.

This pull requests also fixes a type declaration and adds some missing information to the composer.json.