### PR TITLE
Security Check

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "bacon/bacon-qr-code": "^2.0",
         "khanamiryan/qrcode-detector-decoder": "^1.0.2",
         "symfony/http-foundation": "^3.4||^4.2.12||^5.0",
-        "symfony/options-resolver": "^3.4||^4.0||^5.0",
+        "symfony/options-resolver": "^3.4||^4.4.7||^5.0.7",
         "symfony/property-access": "^3.4||^4.0||^5.0",
         "myclabs/php-enum": "^1.5"
     },


### PR DESCRIPTION
https://symfony.com/blog/cve-2020-5255-prevent-cache-poisoning-via-a-response-content-type-header