### PR TITLE
Making setMargin() fluent

### DIFF
--- a/src/QrCode.php
+++ b/src/QrCode.php
@@ -122,9 +122,10 @@ class QrCode implements QrCodeInterface
         return $this->size;
     }
 
-    public function setMargin(int $margin): void
+    public function setMargin(int $margin): self
     {
         $this->margin = $margin;
+        return $this;
     }
 
     public function getMargin(): int


### PR DESCRIPTION
Wouldn't it be easier if all setters would return `$this`, so that you can do this:
```php
$qrCode->setWriterByName('png')->setMargin(10)->setEncoding('UTF-8');
```