### PR TITLE
Explaining margin-size dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ $qrCode->setSize(300);
 
 // Set advanced options
 $qrCode->setWriterByName('png');
-$qrCode->setMargin(10);
+$qrCode->setMargin(10); // the margin is dependent from the size too - see "Readability" below
 $qrCode->setEncoding('UTF-8');
 $qrCode->setErrorCorrectionLevel(ErrorCorrectionLevel::HIGH());
 $qrCode->setForegroundColor(['r' => 0, 'g' => 0, 'b' => 0, 'a' => 0]);
@@ -76,7 +76,7 @@ $response = new QrCodeResponse($qrCode);
 The readability of a QR code is primarily determined by the size, the input
 length, the error correction level and any possible logo over the image so you
 can tweak these parameters if you are looking for optimal results. You can also
-check $qrCode->getRoundBlockSize() value to see if block dimensions are rounded
+check `$qrCode->getRoundBlockSize()` to see if block dimensions are rounded
 so that the image is more sharp and readable. Please note that rounding block
 size can result in additional padding to compensate for the rounding difference.
 


### PR DESCRIPTION
Follow-up of https://github.com/endroid/qr-code/pull/246#issuecomment-614858940

My point is: When you are fighting with the margin (like I did today), you will not look for an explanation called "Readability", since you're having a margin-related issue, not a readability-related.

If you don't like the comment in the code, I think there should be a heading right below the code, saying "Margin is affected by size" (or something like that)