### PR TITLE
Add option to force xlink:href when adding logos in svg

### DIFF
--- a/src/QrCode.php
+++ b/src/QrCode.php
@@ -61,9 +61,6 @@ class QrCode implements QrCodeInterface
     /** @var int|null */
     private $logoHeight;
 
-    /** @var bool */
-    private $logoForceXlinkHref = false;
-
     /** @var string */
     private $label;
 
@@ -235,16 +232,6 @@ class QrCode implements QrCodeInterface
     public function getLogoHeight(): ?int
     {
         return $this->logoHeight;
-    }
-
-    public function setLogoForceXlinkHref(bool $logoForceXlinkHref): void
-    {
-        $this->logoForceXlinkHref = $logoForceXlinkHref;
-    }
-
-    public function getLogoForceXlinkHref(): bool
-    {
-        return $this->logoForceXlinkHref;
     }
 
     public function setLabel(string $label, int $labelFontSize = null, string $labelFontPath = null, string $labelAlignment = null, array $labelMargin = null): void

--- a/src/QrCode.php
+++ b/src/QrCode.php
@@ -61,6 +61,9 @@ class QrCode implements QrCodeInterface
     /** @var int|null */
     private $logoHeight;
 
+    /** @var bool */
+    private $logoForceXlinkHref = false;
+
     /** @var string */
     private $label;
 
@@ -232,6 +235,16 @@ class QrCode implements QrCodeInterface
     public function getLogoHeight(): ?int
     {
         return $this->logoHeight;
+    }
+
+    public function setLogoForceXlinkHref(bool $logoForceXlinkHref): void
+    {
+        $this->logoForceXlinkHref = $logoForceXlinkHref;
+    }
+
+    public function getLogoForceXlinkHref(): bool
+    {
+        return $this->logoForceXlinkHref;
     }
 
     public function setLabel(string $label, int $labelFontSize = null, string $labelFontPath = null, string $labelAlignment = null, array $labelMargin = null): void

--- a/src/QrCodeInterface.php
+++ b/src/QrCodeInterface.php
@@ -35,6 +35,8 @@ interface QrCodeInterface
 
     public function getLogoHeight(): ?int;
 
+    public function getLogoForceXlinkHref(): bool;
+
     public function getLabel(): ?string;
 
     public function getLabelFontPath(): string;

--- a/src/QrCodeInterface.php
+++ b/src/QrCodeInterface.php
@@ -35,8 +35,6 @@ interface QrCodeInterface
 
     public function getLogoHeight(): ?int;
 
-    public function getLogoForceXlinkHref(): bool;
-
     public function getLabel(): ?string;
 
     public function getLabelFontPath(): string;

--- a/src/Writer/SvgWriter.php
+++ b/src/Writer/SvgWriter.php
@@ -64,7 +64,7 @@ class SvgWriter extends AbstractWriter
 
         $logoPath = $qrCode->getLogoPath();
         if (is_string($logoPath)) {
-            $this->addLogo($svg, $data['outer_width'], $data['outer_height'], $logoPath, $qrCode->getLogoWidth(), $qrCode->getLogoHeight());
+            $this->addLogo($svg, $data['outer_width'], $data['outer_height'], $logoPath, $qrCode->getLogoWidth(), $qrCode->getLogoHeight(), $qrCode->getLogoForceXlinkHref());
         }
 
         $xml = $svg->asXML();
@@ -81,7 +81,7 @@ class SvgWriter extends AbstractWriter
         return $xml;
     }
 
-    private function addLogo(SimpleXMLElement $svg, int $imageWidth, int $imageHeight, string $logoPath, int $logoWidth = null, int $logoHeight = null): void
+    private function addLogo(SimpleXMLElement $svg, int $imageWidth, int $imageHeight, string $logoPath, int $logoWidth = null, int $logoHeight = null, bool $forceXlinkHref = false): void
     {
         $mimeType = $this->getMimeType($logoPath);
         $imageData = file_get_contents($logoPath);
@@ -125,7 +125,12 @@ class SvgWriter extends AbstractWriter
         $imageDefinition->addAttribute('width', strval($logoWidth));
         $imageDefinition->addAttribute('height', strval($logoHeight));
         $imageDefinition->addAttribute('preserveAspectRatio', 'none');
-        $imageDefinition->addAttribute('xlink:href', 'data:'.$mimeType.';base64,'.base64_encode($imageData));
+
+        if ($forceXlinkHref) {
+            $imageDefinition['xlink:href'] = 'data:'.$mimeType.';base64,'.base64_encode($imageData);
+        } else {
+            $imageDefinition->addAttribute('href', 'data:'.$mimeType.';base64,'.base64_encode($imageData));
+        }
     }
 
     private function getOpacity(int $alpha): float

--- a/src/Writer/SvgWriter.php
+++ b/src/Writer/SvgWriter.php
@@ -21,6 +21,8 @@ class SvgWriter extends AbstractWriter
 {
     public function writeString(QrCodeInterface $qrCode): string
     {
+        $options = $qrCode->getWriterOptions();
+
         if ($qrCode->getValidateResult()) {
             throw new ValidationException('Built-in validation reader can not check SVG images: please disable via setValidateResult(false)');
         }
@@ -64,7 +66,13 @@ class SvgWriter extends AbstractWriter
 
         $logoPath = $qrCode->getLogoPath();
         if (is_string($logoPath)) {
-            $this->addLogo($svg, $data['outer_width'], $data['outer_height'], $logoPath, $qrCode->getLogoWidth(), $qrCode->getLogoHeight(), $qrCode->getLogoForceXlinkHref());
+
+            $forceXlinkHref = false;
+            if (isset($options['force_xlink_href']) && $options['force_xlink_href']) {
+                $forceXlinkHref = true;
+            }
+
+            $this->addLogo($svg, $data['outer_width'], $data['outer_height'], $logoPath, $qrCode->getLogoWidth(), $qrCode->getLogoHeight(), $forceXlinkHref);
         }
 
         $xml = $svg->asXML();
@@ -73,7 +81,7 @@ class SvgWriter extends AbstractWriter
             throw new GenerateImageException('Unable to save SVG XML');
         }
 
-        $options = $qrCode->getWriterOptions();
+
         if (isset($options['exclude_xml_declaration']) && $options['exclude_xml_declaration']) {
             $xml = str_replace("<?xml version=\"1.0\"?>\n", '', $xml);
         }

--- a/src/Writer/SvgWriter.php
+++ b/src/Writer/SvgWriter.php
@@ -126,6 +126,8 @@ class SvgWriter extends AbstractWriter
         $imageDefinition->addAttribute('height', strval($logoHeight));
         $imageDefinition->addAttribute('preserveAspectRatio', 'none');
 
+        // xlink:href is actually deprecated, but still required when placing the qr code in a pdf.
+        // SimpleXML strips out the xlink part by using addAttribute(), so it must be set directly.
         if ($forceXlinkHref) {
             $imageDefinition['xlink:href'] = 'data:'.$mimeType.';base64,'.base64_encode($imageData);
         } else {


### PR DESCRIPTION
This PR is kind of a bugfix, kind of an enhancement.

**Background:**
In https://github.com/endroid/qr-code/pull/173 the functionality to add logo in svg qr codes was added. The `xlink:href` attribute was used to add the embedded image (see [SvgWriter.php#L53](https://github.com/Woodehh/qr-code/blob/master/src/Writer/SvgWriter.php#L53)).

But `SimpleXML` turns the `xlink:href` attribute into a `href` attribute, as [this blog post ](https://blog.jondh.me.uk/2010/10/resetting-namespaced-attributes-using-simplexml/)from 10 years ago(!) already stated. So far so good, because in SVG `xlink:href` [is actually deprecated](https://www.w3.org/TR/SVG2/linking.html#XLinkRefAttrs).

Yet there is a catch: If you put an svg-qrcode with an embedded logo into a pdf, the `xlink:href` attribute is expected. Otherwise the logo simply does not show, just the normal qr code. We could confirm this issue with current versions of PrinceXML and TCPDF [in this issue](https://github.com/sprain/php-swiss-qr-bill/issues/51) over at our library.

**What this pr does:**

* The `xlink:href` attribute is by default replaced with a `href` attribute, as this is anyways what you get in the end and is the way it should be done.

* But if you still rely on the `xlink:href` attribute, this pr adds the option to  set `$qrCode->setWriterOptions(['force_xlink_href' => true])`, which then will enforce this older attribute with the trick from the blog mentioned above.

I know this is edge-casey, but it would be very helpful if this could get merged :)