### PR TITLE
Added an exception to allow non alpha png files written

### DIFF
--- a/src/Writer/PngWriter.php
+++ b/src/Writer/PngWriter.php
@@ -96,7 +96,9 @@ class PngWriter extends AbstractWriter
         $backgroundColor = imagecolorallocatealpha($image, $qrCode->getBackgroundColor()['r'], $qrCode->getBackgroundColor()['g'], $qrCode->getBackgroundColor()['b'], $qrCode->getBackgroundColor()['a']);
         imagefill($image, 0, 0, $backgroundColor);
         imagecopyresampled($image, $baseImage, (int) $data['margin_left'], (int) $data['margin_left'], 0, 0, (int) $data['inner_width'], (int) $data['inner_height'], imagesx($baseImage), imagesy($baseImage));
-        imagesavealpha($image, true);
+
+        if($qrCode->getBackgroundColor()['a'] > 0)
+          imagesavealpha($image, true);
 
         return $image;
     }


### PR DESCRIPTION
if alpha channel is set to 0. An alpha channel is only added, if this value is between 1 and 127 (higher value than 127 is not allowed by php).

I created an issue before and decided to provide a pull request for this: https://github.com/endroid/qr-code/issues/264