### PR TITLE
Add Symfony 3.x compatibility for 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,21 +15,21 @@
     "require": {
         "php": ">=5.6",
         "ext-gd": "*",
-        "symfony/options-resolver": "^2.7",
+        "symfony/options-resolver": "^2.7||^3.4",
         "bacon/bacon-qr-code": "^1.0.3",
-        "khanamiryan/qrcode-detector-decoder": "1",
-        "symfony/property-access": "^2.7",
+        "khanamiryan/qrcode-detector-decoder": "^1.0.3",
+        "symfony/property-access": "^2.7||^3.4",
         "myclabs/php-enum": "^1.5"
     },
     "require-dev": {
-        "symfony/asset": "^2.7",
-        "symfony/browser-kit": "^2.7",
-        "symfony/finder": "^2.7",
-        "symfony/framework-bundle": "^2.7",
-        "symfony/http-kernel": "^2.7",
-        "symfony/templating": "^2.7",
-        "symfony/twig-bundle": "^2.7",
-        "symfony/yaml": "^2.7",
+        "symfony/asset": "^2.7||^3.4",
+        "symfony/browser-kit": "^2.7||^3.4",
+        "symfony/finder": "^2.7||^3.4",
+        "symfony/framework-bundle": "^2.7||^3.4",
+        "symfony/http-kernel": "^2.7||^3.4",
+        "symfony/templating": "^2.7||^3.4",
+        "symfony/twig-bundle": "^2.7||^3.4",
+        "symfony/yaml": "^2.7||^3.4",
         "phpunit/phpunit": "^5.7"
     },
     "autoload": {

--- a/src/Writer/PngWriter.php
+++ b/src/Writer/PngWriter.php
@@ -15,7 +15,7 @@ use Endroid\QrCode\Exception\MissingFunctionException;
 use Endroid\QrCode\Exception\ValidationException;
 use Endroid\QrCode\LabelAlignment;
 use Endroid\QrCode\QrCodeInterface;
-use QrReader;
+use Zxing\QrReader;
 
 class PngWriter extends AbstractBaconWriter
 {


### PR DESCRIPTION
I know this isn't recommended at all (#182), but this adds support for Symfony 3.x if on older setups if you need something bridging until shifting up to a newer version.