### PR TITLE
Implements logo background punchout functionality

### DIFF
--- a/src/Builder/Builder.php
+++ b/src/Builder/Builder.php
@@ -135,6 +135,13 @@ class Builder implements BuilderInterface
         return $this;
     }
 
+    public function logoPunchoutBackground(bool $logoPunchoutBackground): BuilderInterface
+    {
+        $this->options['logoPunchoutBackground'] = $logoPunchoutBackground;
+
+        return $this;
+    }
+
     public function labelText(string $labelText): BuilderInterface
     {
         $this->options['labelText'] = $labelText;

--- a/src/Builder/BuilderInterface.php
+++ b/src/Builder/BuilderInterface.php
@@ -45,6 +45,8 @@ interface BuilderInterface
 
     public function logoResizeToHeight(int $logoResizeToHeight): BuilderInterface;
 
+    public function logoPunchoutBackground(bool $logoPunchoutBackground): BuilderInterface;
+
     public function labelText(string $labelText): BuilderInterface;
 
     public function labelFont(FontInterface $labelFont): BuilderInterface;

--- a/src/ImageData/LogoImageData.php
+++ b/src/ImageData/LogoImageData.php
@@ -23,19 +23,24 @@ class LogoImageData
     /** @var int */
     private $height;
 
+    /** @var bool */
+    private $punchoutBackground;
+
     /** @param mixed $image */
     private function __construct(
         string $data,
         $image,
         string $mimeType,
         int $width,
-        int $height
+        int $height,
+        bool $punchoutBackground
     ) {
         $this->data = $data;
         $this->image = $image;
         $this->mimeType = $mimeType;
         $this->width = $width;
         $this->height = $height;
+        $this->punchoutBackground = $punchoutBackground;
     }
 
     public static function createForLogo(LogoInterface $logo): self
@@ -71,20 +76,20 @@ class LogoImageData
 
         // No target width and height specified: use from original image
         if (null !== $width && null !== $height) {
-            return new self($data, $image, $mimeType, $width, $height);
+            return new self($data, $image, $mimeType, $width, $height, $logo->getPunchoutBackground());
         }
 
         // Only target width specified: calculate height
         if (null !== $width && null === $height) {
-            return new self($data, $image, $mimeType, $width, intval(imagesy($image) * $width / imagesx($image)));
+            return new self($data, $image, $mimeType, $width, intval(imagesy($image) * $width / imagesx($image)), $logo->getPunchoutBackground());
         }
 
         // Only target height specified: calculate width
         if (null === $width && null !== $height) {
-            return new self($data, $image, $mimeType, intval(imagesx($image) * $height / imagesy($image)), $height);
+            return new self($data, $image, $mimeType, intval(imagesx($image) * $height / imagesy($image)), $height, $logo->getPunchoutBackground());
         }
 
-        return new self($data, $image, $mimeType, imagesx($image), imagesy($image));
+        return new self($data, $image, $mimeType, imagesx($image), imagesy($image), $logo->getPunchoutBackground());
     }
 
     public function getData(): string
@@ -111,6 +116,11 @@ class LogoImageData
     public function getHeight(): int
     {
         return $this->height;
+    }
+
+    public function getPunchoutBackground(): bool
+    {
+        return $this->punchoutBackground;
     }
 
     public function createDataUri(): string

--- a/src/Logo/Logo.php
+++ b/src/Logo/Logo.php
@@ -15,11 +15,12 @@ final class Logo implements LogoInterface
     /** @var int|null */
     private $resizeToHeight;
 
-    public function __construct(string $path, ?int $resizeToWidth = null, ?int $resizeToHeight = null)
+    public function __construct(string $path, ?int $resizeToWidth = null, ?int $resizeToHeight = null, ?bool $punchoutBackground = false)
     {
         $this->path = $path;
         $this->resizeToWidth = $resizeToWidth;
         $this->resizeToHeight = $resizeToHeight;
+        $this->punchoutBackground = $punchoutBackground;
     }
 
     public static function create(string $path): self
@@ -59,6 +60,18 @@ final class Logo implements LogoInterface
     public function setResizeToHeight(?int $resizeToHeight): self
     {
         $this->resizeToHeight = $resizeToHeight;
+
+        return $this;
+    }
+
+    public function getPunchoutBackground(): ?bool
+    {
+        return $this->punchoutBackground;
+    }
+
+    public function setPunchoutBackground(?bool $punchoutBackground): self
+    {
+        $this->punchoutBackground = $punchoutBackground;
 
         return $this;
     }

--- a/src/Logo/LogoInterface.php
+++ b/src/Logo/LogoInterface.php
@@ -11,4 +11,6 @@ interface LogoInterface
     public function getResizeToWidth(): ?int;
 
     public function getResizeToHeight(): ?int;
+
+    public function getPunchoutBackground(): ?bool;
 }

--- a/src/Writer/PngWriter.php
+++ b/src/Writer/PngWriter.php
@@ -138,6 +138,29 @@ final class PngWriter implements WriterInterface, ValidatingWriterInterface
 
         $targetImage = $result->getImage();
 
+        if($logoImageData->getPunchoutBackground()) {
+            $transparent = imagecolorallocatealpha($targetImage, 255, 255, 255, 127);
+            imagealphablending($targetImage, false);
+            for(
+                $x_offset = intval(imagesx($targetImage) / 2 - $logoImageData->getWidth() / 2);
+                $x_offset < intval(imagesx($targetImage) / 2 - $logoImageData->getWidth() / 2) + $logoImageData->getWidth();
+                $x_offset++
+            ) {
+                for(
+                    $y_offset = intval(imagesy($targetImage) / 2 - $logoImageData->getHeight() / 2);
+                    $y_offset < intval(imagesy($targetImage) / 2 - $logoImageData->getHeight() / 2) + $logoImageData->getHeight();
+                    $y_offset++
+                ) {
+                    imagesetpixel(
+                        $targetImage,
+                        $x_offset,
+                        $y_offset,
+                        $transparent
+                    );
+                }
+            }
+        }
+
         imagecopyresampled(
             $targetImage,
             $logoImageData->getImage(),


### PR DESCRIPTION
Currently if you want to use a logo with transparency on top of a QR code the QR code will show through, this "punches out" a hole in the QR code the size of the logo.