### PR TITLE
Add missing namespace for xlink logo in SvgWriter

### DIFF
--- a/src/Writer/SvgWriter.php
+++ b/src/Writer/SvgWriter.php
@@ -98,8 +98,6 @@ final class SvgWriter implements WriterInterface
         $imageDefinition->addAttribute('height', strval($logoImageData->getHeight()));
         $imageDefinition->addAttribute('preserveAspectRatio', 'none');
 
-        // xlink:href is actually deprecated, but still required when placing the qr code in a pdf.
-        // SimpleXML strips out the xlink part by using addAttribute(), so it must be set directly.
         if ($options[self::WRITER_OPTION_FORCE_XLINK_HREF]) {
             $imageDefinition->addAttribute('xlink:href', $logoImageData->createDataUri(), 'http://www.w3.org/1999/xlink');
         } else {

--- a/src/Writer/SvgWriter.php
+++ b/src/Writer/SvgWriter.php
@@ -101,7 +101,7 @@ final class SvgWriter implements WriterInterface
         // xlink:href is actually deprecated, but still required when placing the qr code in a pdf.
         // SimpleXML strips out the xlink part by using addAttribute(), so it must be set directly.
         if ($options[self::WRITER_OPTION_FORCE_XLINK_HREF]) {
-            $imageDefinition->addAttribute('xlink:href', $logoImageData->createDataUri());
+            $imageDefinition->addAttribute('xlink:href', $logoImageData->createDataUri(), 'http://www.w3.org/1999/xlink');
         } else {
             $imageDefinition->addAttribute('href', $logoImageData->createDataUri());
         }


### PR DESCRIPTION
This missing namespace causes the logo to not appear when embedding the qr code in a pdf.