### PR TITLE
Suppress unexpected libpng warning when added a logo

### DIFF
--- a/src/ImageData/LogoImageData.php
+++ b/src/ImageData/LogoImageData.php
@@ -60,7 +60,7 @@ class LogoImageData
             return new self($data, null, $mimeType, $width, $height, $logo->getPunchoutBackground());
         }
 
-        $image = imagecreatefromstring($data);
+        $image = @imagecreatefromstring($data);
 
         if (!$image) {
             throw new \Exception(sprintf('Unable to parse image data at path "%s"', $logo->getPath()));


### PR DESCRIPTION
PHP Version: 8.1.0

Problem:
When added some png files as a logo, it will throw a warning like this:

`PHP Warning:  imagecreatefromstring(): gd-png: libpng warning: iCCP: known incorrect sRGB profile`

In some php frameworks, they treated it as an exception which end the program immediately and cannot generate the qr code.



Related issue:
https://github.com/dompdf/dompdf/issues/2718

Reproduce:
```php
<?php
$data = file_get_contents("https://user-images.githubusercontent.com/1336778/167459293-12d01436-33ac-432d-b8a1-fac00ef113c1.png");

// Error!!
$im = imagecreatefromstring($data);

// Fix
// $im = @imagecreatefromstring($data);

if ($im !== false) {
    echo "OK";
} else {
    echo "Not OK";
}
```