### PR TITLE
LogoImageData::createForLogo Verbose Errors

### DIFF
--- a/src/ImageData/LogoImageData.php
+++ b/src/ImageData/LogoImageData.php
@@ -18,9 +18,17 @@ class LogoImageData
     ) {
     }
 
-    public static function createForLogo(LogoInterface $logo): self
+    public static function createForLogo(LogoInterface $logo, bool $verboseErrors = false): self
     {
-        $data = @file_get_contents($logo->getPath());
+        if ($verboseErrors) {
+            try {
+                $data = file_get_contents($logo->getPath());
+            } catch (\Exception $e) {
+                throw new \Exception(sprintf('Failed to get file contents with error: %s', $e->getMessage()));
+            }
+        } else {
+            $data = @file_get_contents($logo->getPath());
+        }
 
         if (!is_string($data)) {
             throw new \Exception(sprintf('Invalid data at path "%s"', $logo->getPath()));
@@ -43,7 +51,15 @@ class LogoImageData
             return new self($data, null, $mimeType, $width, $height, $logo->getPunchoutBackground());
         }
 
-        $image = @imagecreatefromstring($data);
+        if ($verboseErrors) {
+            try {
+                $image = imagecreatefromstring($data);
+            } catch (\Exception $e) {
+                throw new \Exception(sprintf('Failed to create image from sting with error: %s', $e->getMessage()));
+            }
+        } else {
+            $image = @imagecreatefromstring($data);
+        }
 
         if (!$image) {
             throw new \Exception(sprintf('Unable to parse image data at path "%s"', $logo->getPath()));


### PR DESCRIPTION
Hi @endroid, thanks for this library it is very helpful.

I have run into a situation where the `standard_5.php` and `gd.php` methods used in `createForLogo()` (`file_get_contents`, `imagecreatefromstring`) have errors suppressed due to the `@` prefix. It would be very helpful to have greater insight into the errors with my current implementation and was wondering if something like the proposed changes would be a possibility? 

Clearly this is the first/quick solution that came to mind and it is not a necessity but I figured I would open this PR to start a discussion and did not want to come empty handed.

Having the option to not suppress the potential errors would help to gain further insight. We already get the generic error just below the `try/catch` if the return is not a string or image. But this skips the root cause of the issue from being shown if something goes wrong when the original methods are being called. I'm open to any ideas.

Thanks either way for your consideration and thanks again for this repo!