### PR TITLE
Additional SvgWriterCompact class for rendering optimized SVG Markup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 /composer.lock
 /tests/coverage/
 /vendor/
+
+/src/BaconQrCode/
+/src/dasprid/

--- a/src/Writer/SvgWriterCompact.php
+++ b/src/Writer/SvgWriterCompact.php
@@ -1,0 +1,331 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Endroid\QrCode\Writer;
+
+use Endroid\QrCode\Bacon\MatrixFactory;
+use Endroid\QrCode\ImageData\LogoImageData;
+use Endroid\QrCode\Label\LabelInterface;
+use Endroid\QrCode\Logo\LogoInterface;
+use Endroid\QrCode\QrCodeInterface;
+use Endroid\QrCode\Writer\Result\ResultInterface;
+use Endroid\QrCode\Writer\Result\SvgResult;
+
+final class SvgWriterCompact implements WriterInterface
+{
+    public const DECIMAL_PRECISION = 10;
+    public const WRITER_OPTION_BLOCK_ID = 'block_id';
+    public const WRITER_OPTION_EXCLUDE_XML_DECLARATION = 'exclude_xml_declaration';
+    public const WRITER_OPTION_EXCLUDE_SVG_WIDTH_AND_HEIGHT = 'exclude_svg_width_and_height';
+    public const WRITER_OPTION_FORCE_XLINK_HREF = 'force_xlink_href';
+
+    public function write(QrCodeInterface $qrCode, LogoInterface $logo = null, LabelInterface $label = null, array $options = []): ResultInterface
+    {
+        if (!isset($options[self::WRITER_OPTION_BLOCK_ID])) {
+            $options[self::WRITER_OPTION_BLOCK_ID] = 'block';
+        }
+
+        if (!isset($options[self::WRITER_OPTION_EXCLUDE_XML_DECLARATION])) {
+            $options[self::WRITER_OPTION_EXCLUDE_XML_DECLARATION] = false;
+        }
+
+        if (!isset($options[self::WRITER_OPTION_EXCLUDE_SVG_WIDTH_AND_HEIGHT])) {
+            $options[self::WRITER_OPTION_EXCLUDE_SVG_WIDTH_AND_HEIGHT] = false;
+        }
+
+        $matrixFactory = new MatrixFactory();
+        $matrix = $matrixFactory->create($qrCode);
+
+
+
+
+
+		//echo("<pre>" . print_r($matrix, true) . "</pre>");
+
+		/*===== I) =====
+		group adjacent blocks to reduce path drawing instructions later on
+		*/
+		$bcount = $matrix->getBlockCount();
+		$bsize = $matrix->getBlockSize();
+
+		//absolute offsets for first block relative to top left corner of the canvas (0/0)
+		$xoff = $yoff = $matrix->getMarginLeft();
+
+		//array to collect line Arrays
+		$rows = [];
+
+		//traverse matrix and collect block groups line by line
+		for($rowIndex = 0; $rowIndex < $bcount; $rowIndex++){
+
+			//local line array to collect block groups for one rowIndex
+			$linea = [];
+
+			//running variable for grouping
+			$g = null;
+
+			//blocks in this line
+			for($columnIndex = 0; $columnIndex < $bcount; $columnIndex++){
+
+				//get block value
+				$v = $matrix->getBlockValue($rowIndex, $columnIndex);
+
+				if($v === 1){
+					// [1] : this block has to be drawn
+
+					//If there is no running group "open" - create a new one
+					if(!$g){
+						//The actual block is the first block in the group and determines
+						//the matrix x/y position for this group of adjacent blocks
+						$g = new SvgWriterCompact_Blockgroup($columnIndex, $rowIndex);
+					}
+
+					//always count the actual block for the running group (1-n)
+					$g->bcount++;
+				}
+				else{
+					// [0] : this block has not to be drawn (gap)
+					//It does not belong to the running group
+
+					//close the running group and calc its rectangular shape
+					if($g){
+						//calculate drawing reactangle immediately to use it in the follwing steps directly
+						$g->calc($xoff, $yoff, $bsize);
+
+						//collect the group for the actual line
+						$linea[] = $g;
+					}
+
+					//reset running variable!
+					//With this a new group will be opened as soon
+					//as the next no empty block [1] appears in the following for columnIndex loops
+					$g = null;
+				}
+			}
+
+			//after the last block for this line has been processed there might be
+			//a group remaining "open". This happens if the last block in this line
+			//had a block value of [1].
+			if($g){
+				//finish this group
+				$g->calc($xoff, $yoff, $bsize);
+
+				//collect it for this line
+				$linea[] = $g;
+			}
+
+			//finally collect all groups for this line
+			$rows[] = $linea;
+		}
+		//echo("<pre>" . print_r($rows, true) . "</pre>");
+
+
+
+		/*===== II) =====
+		We could create <rect> Elements for each block group. But this will also produce
+		a lot of SVG markup and does not solve the problem of flashing lines between adjacent blocks.
+		The proper solution ist to combine als drawing statements into one <path> Element.
+		This removes flashing edges in al browsers as well in all tested graphics software.
+		The reason might be hat the resulting combined path ist handled as only one path
+		and not a group of pathes.
+		further reading at: https://www.mediaevent.de/tutorial/svg-path.html
+		*/
+		//array for collecting single rectangular drawing statements M...Z
+		$da = [];
+		foreach($rows as $linea){
+			foreach($linea as $p){
+				//draw one closed rectangular shape
+				//It's allowed to chain multiple line segment statements without separating whitespace.
+				//We move the cursor to the start position "M", draw linear path segments
+				//with "L" clockwise and close the rectangular shape with "Z".
+				$da[] = "M{$p->x1},{$p->y1}L{$p->x2},{$p->y1}L{$p->x2},{$p->y2}L{$p->x1},{$p->y2}Z";
+			}
+		}
+		//Now the draw statements of all block groups for all rows are combined in one single
+		//statement that can be set as the @d Attribute of the <path> Element.
+		$path_d = implode(" ", $da);
+
+
+
+		//===== III) create SVG =====
+		//root element
+		$xml = new \SimpleXMLElement('<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"/>');
+		$xml->addAttribute('version', '1.1');
+		if (!$options[self::WRITER_OPTION_EXCLUDE_SVG_WIDTH_AND_HEIGHT]) {
+			$xml->addAttribute('width', $matrix->getOuterSize().'px');
+			$xml->addAttribute('height', $matrix->getOuterSize().'px');
+		}
+		$xml->addAttribute('viewBox', '0 0 '.$matrix->getOuterSize().' '.$matrix->getOuterSize());
+
+		//background rectangle
+        $background = $xml->addChild('rect');
+        $background->addAttribute('x', '0');
+        $background->addAttribute('y', '0');
+        $background->addAttribute('width', strval($matrix->getOuterSize()));
+        $background->addAttribute('height', strval($matrix->getOuterSize()));
+        $background->addAttribute('fill', '#'.sprintf('%02x%02x%02x', $qrCode->getBackgroundColor()->getRed(), $qrCode->getBackgroundColor()->getGreen(), $qrCode->getBackgroundColor()->getBlue()));
+        $background->addAttribute('fill-opacity', strval($qrCode->getBackgroundColor()->getOpacity()));
+
+		//Symbol as one combined path with all blocks
+		$pelm = $xml->addChild("path");
+		//fill color
+		$fc = '#'.sprintf('%02x%02x%02x', $qrCode->getForegroundColor()->getRed(), $qrCode->getForegroundColor()->getGreen(), $qrCode->getForegroundColor()->getBlue());
+		//fill opacity
+		$fo = strval($qrCode->getForegroundColor()->getOpacity());
+		$pelm->addAttribute("fill", $fc);
+		$pelm->addAttribute("fill-opacity", $fo);
+		//The drawing statement for all blocks at once
+		$pelm->addAttribute("d", $path_d);
+
+
+
+/*
+//old method
+        $xml = new \SimpleXMLElement('<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"/>');
+        $xml->addAttribute('version', '1.1');
+        if (!$options[self::WRITER_OPTION_EXCLUDE_SVG_WIDTH_AND_HEIGHT]) {
+            $xml->addAttribute('width', $matrix->getOuterSize().'px');
+            $xml->addAttribute('height', $matrix->getOuterSize().'px');
+        }
+        $xml->addAttribute('viewBox', '0 0 '.$matrix->getOuterSize().' '.$matrix->getOuterSize());
+        $xml->addChild('defs');
+
+        $blockDefinition = $xml->defs->addChild('rect');
+        $blockDefinition->addAttribute('id', strval($options[self::WRITER_OPTION_BLOCK_ID]));
+        $blockDefinition->addAttribute('width', number_format($matrix->getBlockSize(), self::DECIMAL_PRECISION, '.', ''));
+        $blockDefinition->addAttribute('height', number_format($matrix->getBlockSize(), self::DECIMAL_PRECISION, '.', ''));
+        $blockDefinition->addAttribute('fill', '#'.sprintf('%02x%02x%02x', $qrCode->getForegroundColor()->getRed(), $qrCode->getForegroundColor()->getGreen(), $qrCode->getForegroundColor()->getBlue()));
+        $blockDefinition->addAttribute('fill-opacity', strval($qrCode->getForegroundColor()->getOpacity()));
+
+        $background = $xml->addChild('rect');
+        $background->addAttribute('x', '0');
+        $background->addAttribute('y', '0');
+        $background->addAttribute('width', strval($matrix->getOuterSize()));
+        $background->addAttribute('height', strval($matrix->getOuterSize()));
+        $background->addAttribute('fill', '#'.sprintf('%02x%02x%02x', $qrCode->getBackgroundColor()->getRed(), $qrCode->getBackgroundColor()->getGreen(), $qrCode->getBackgroundColor()->getBlue()));
+        $background->addAttribute('fill-opacity', strval($qrCode->getBackgroundColor()->getOpacity()));
+
+        for ($rowIndex = 0; $rowIndex < $matrix->getBlockCount(); ++$rowIndex) {
+            for ($columnIndex = 0; $columnIndex < $matrix->getBlockCount(); ++$columnIndex) {
+                if (1 === $matrix->getBlockValue($rowIndex, $columnIndex)) {
+                    $block = $xml->addChild('use');
+                    $block->addAttribute('x', number_format($matrix->getMarginLeft() + $matrix->getBlockSize() * $columnIndex, self::DECIMAL_PRECISION, '.', ''));
+                    $block->addAttribute('y', number_format($matrix->getMarginLeft() + $matrix->getBlockSize() * $rowIndex, self::DECIMAL_PRECISION, '.', ''));
+                    $block->addAttribute('xlink:href', '#'.$options[self::WRITER_OPTION_BLOCK_ID], 'http://www.w3.org/1999/xlink');
+                }
+            }
+        }
+
+//insert <path> Element as overlay to check
+//if it fits all blocks drawn by the old method with <use> Elements.
+$pelm = $xml->addChild("path");
+$pelm->addAttribute("fill", "red");
+$pelm->addAttribute("fill-opacity", "0.5");
+$pelm->addAttribute("d", $path_d);
+
+*/
+
+        $result = new SvgResult($matrix, $xml, boolval($options[self::WRITER_OPTION_EXCLUDE_XML_DECLARATION]));
+
+        if ($logo instanceof LogoInterface) {
+            $this->addLogo($logo, $result, $options);
+        }
+
+        return $result;
+    }
+
+    /** @param array<string, mixed> $options */
+    private function addLogo(LogoInterface $logo, SvgResult $result, array $options): void
+    {
+        $logoImageData = LogoImageData::createForLogo($logo);
+
+        if (!isset($options[self::WRITER_OPTION_FORCE_XLINK_HREF])) {
+            $options[self::WRITER_OPTION_FORCE_XLINK_HREF] = false;
+        }
+
+        $xml = $result->getXml();
+
+        /** @var \SimpleXMLElement $xmlAttributes */
+        $xmlAttributes = $xml->attributes();
+
+        $x = intval($xmlAttributes->width) / 2 - $logoImageData->getWidth() / 2;
+        $y = intval($xmlAttributes->height) / 2 - $logoImageData->getHeight() / 2;
+
+        $imageDefinition = $xml->addChild('image');
+        $imageDefinition->addAttribute('x', strval($x));
+        $imageDefinition->addAttribute('y', strval($y));
+        $imageDefinition->addAttribute('width', strval($logoImageData->getWidth()));
+        $imageDefinition->addAttribute('height', strval($logoImageData->getHeight()));
+        $imageDefinition->addAttribute('preserveAspectRatio', 'none');
+
+        if ($options[self::WRITER_OPTION_FORCE_XLINK_HREF]) {
+            $imageDefinition->addAttribute('xlink:href', $logoImageData->createDataUri(), 'http://www.w3.org/1999/xlink');
+        } else {
+            $imageDefinition->addAttribute('href', $logoImageData->createDataUri());
+        }
+    }
+}
+
+
+
+//Hilfsklasse QR Blockgruppe z.B. zur Weiterverarbeitung SVG
+//Führt 1-n QR-Code Pixel zu einer Grupppe zusamen,
+//aus der ein Rechteck zum Zeichnen berechnet werden kann.
+class SvgWriterCompact_Blockgroup{
+	//start index in matrix, 0-n
+	public $ix = 0;
+	public $iy = 0;
+
+	//number of blocks in this group, 1-n
+	public $bcount = 0;
+
+	//absolute positions and size
+	public $x1 = 0;
+	public $y1 = 0;
+	public $w = 0;
+	public $h = 0;
+	public $x2 = 0;
+	public $y2 = 0;
+
+	/*
+	calculate drawing rectangle in absolute pixel coordinates
+	The rectangle may be a square if the group contains only one block,
+	or a more or less wide rectangle depending of blocks in the group.
+	This drawing rectangle can be used to render a SVG <rect> element
+	or a drawing statement for a SVG <path> element @d Attribute.
+
+	ATTENTION: i assume that for SVG the default setRoundBlockSizeMode is the
+	only reasonable mode and therefore all values are INT.
+
+	For resolution independend vector graphics this might be irrelevant.
+	But float numbers produce a large amount of redundant overhead in the coordinate values.
+	SVG output of "M 10.0000000000,20.0000000000" is completely useless.
+	Better ist "M 10,20".
+
+	The resulting SVG vectorgraphic file only consists of rectangular shapes with rounded
+	values and can be positioned/edited in any vector graphics software and scaled to any size
+	always at highest quality.
+
+	There is no reason for highest precision in the point values here.
+	*/
+	function calc($xoff=0, $yoff=0, $block_size=0){
+		//top left corner
+		$this->x1 = $xoff + ($this->ix * $block_size);
+		$this->y1 = $yoff + ($this->iy * $block_size);
+
+		//width/height
+		$this->w = $this->bcount * $block_size;
+		$this->h = $block_size;
+
+		//bottom right corner
+		$this->x2 = $this->x1 + $this->w;
+		$this->y2 = $this->y1 + $this->h;
+	}
+
+	function __construct($ix=0, $iy=0, $posx=0, $posy=0){
+		$this->ix = $ix;
+		$this->iy = $iy;
+		$this->x1 = $posx;
+		$this->y1 = $posy;
+	}
+}

--- a/tests/4dimageTest.php
+++ b/tests/4dimageTest.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Endroid\QrCode\Tests;
+
+use Endroid\QrCode\Bacon\MatrixFactory;
+use Endroid\QrCode\Builder\Builder;
+use Endroid\QrCode\Color\Color;
+use Endroid\QrCode\Encoding\Encoding;
+use Endroid\QrCode\ErrorCorrectionLevel;
+use Endroid\QrCode\Label\Label;
+use Endroid\QrCode\Logo\Logo;
+use Endroid\QrCode\Matrix\MatrixInterface;
+use Endroid\QrCode\QrCode;
+use Endroid\QrCode\RoundBlockSizeMode;
+use Endroid\QrCode\Writer\BinaryWriter;
+use Endroid\QrCode\Writer\ConsoleWriter;
+use Endroid\QrCode\Writer\DebugWriter;
+use Endroid\QrCode\Writer\EpsWriter;
+use Endroid\QrCode\Writer\GifWriter;
+use Endroid\QrCode\Writer\PdfWriter;
+use Endroid\QrCode\Writer\PngWriter;
+use Endroid\QrCode\Writer\Result\BinaryResult;
+use Endroid\QrCode\Writer\Result\ConsoleResult;
+use Endroid\QrCode\Writer\Result\DebugResult;
+use Endroid\QrCode\Writer\Result\EpsResult;
+use Endroid\QrCode\Writer\Result\GifResult;
+use Endroid\QrCode\Writer\Result\PdfResult;
+use Endroid\QrCode\Writer\Result\PngResult;
+use Endroid\QrCode\Writer\Result\SvgResult;
+use Endroid\QrCode\Writer\Result\WebpResult;
+use Endroid\QrCode\Writer\SvgWriter;
+use Endroid\QrCode\Writer\ValidatingWriterInterface;
+use Endroid\QrCode\Writer\WebPWriter;
+use Endroid\QrCode\Writer\WriterInterface;
+
+use Endroid\QrCode\Writer\SvgWriterCompact;
+
+
+spl_autoload_register(function($class_name){
+	$cpath = str_replace("Endroid\\QrCode\\", "", $class_name);
+
+	$fpath = "../src/" . $cpath . ".php";
+/*
+echo("
+<pre>
+class_name: $class_name
+cpath: $cpath
+fpath: $fpath
+</pre>
+");
+*/
+	if(@file_exists($fpath))require_once $fpath;
+});
+
+class C4dTest{
+	public static function testSvgWriterCompact(int $writerSwitch=0){
+		$dataString = "https://www.4d-image.de/";
+
+		$size = 1024;
+		$margin = 62;
+		$size_use = $size - ($margin * 2);
+
+		$qrCode = QrCode::create($dataString)
+			->setEncoding(new Encoding('UTF-8'))
+			->setErrorCorrectionLevel(ErrorCorrectionLevel::Low)
+            ->setSize($size_use)
+            ->setMargin($margin)
+            ->setRoundBlockSizeMode(RoundBlockSizeMode::Margin)
+            ->setForegroundColor(new Color(0, 0, 0))
+            ->setBackgroundColor(new Color(255, 255, 255));
+
+		if($writerSwitch === 1){
+			//use new SVGWriterCompact
+			$writer = new SvgWriterCompact();
+		}
+		else{
+			//use default SvgWriter
+			$writer = new SvgWriter();
+		}
+
+		$result = $writer->write($qrCode);
+
+		// Directly output the QR code
+		header('Content-Type: '.$result->getMimeType());
+		echo $result->getString();
+	}
+}
+
+//Respond with QR-Code Data instead of HTML test document.
+$mode = filter_input(
+	INPUT_GET,
+	"mode"
+);
+if(!$mode)$mode = "";
+
+
+//switch between writers
+$writer = filter_input(
+	INPUT_GET,
+	"writer",
+	FILTER_VALIDATE_INT,
+	[
+		"options" => [
+			"default" => 0,
+			"min_range" => 0,
+			"max_range" => 1
+		]
+	]
+);
+
+if($mode === "data"){
+	C4dTest::testSvgWriterCompact($writer);
+	die();
+}
+
+//source URLs of the <img> elements in the <body>
+$img_src = "?mode=data&writer=0";
+$img_src_1 = "?mode=data&writer=1";
+
+?><!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>qr-code SvgWriterCompact demo</title>
+<meta name="description" content="">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
+<style>
+html, html *{
+	box-sizing:border-box;
+}
+html{
+	font-family:sans-serif;
+	font-size:16px;
+}
+
+img{
+	max-width:100%;
+	height:auto;
+}
+.codes{
+	display:flex;
+	flex-wrap:wrap;
+	align-items:start;
+}
+</style>
+</head>
+<body>
+
+<!--
+<pre>
+<?php
+echo("
+mode: $mode
+writer: $writer
+img_src: $img_src
+");
+?>
+</pre>
+-->
+
+<h2>SvgWriter (default)</h2>
+<ol>
+<li>Causes thin flashing edges between adjacent blocks when not displayed at intrinsic size</li>
+<li>Large file size simply because of redundant SVG markup</li>
+</ol>
+<div class="codes">
+<img src="<?=$img_src?>" width="512" height="512" alt="QR-Code">
+<img src="<?=$img_src?>" width="256" height="256" alt="QR-Code">
+<img src="<?=$img_src?>" width="128" height="128" alt="QR-Code">
+</div>
+<hr>
+
+<h2>SvgWriterCompact</h2>
+<ol>
+<li>No flashing edges no matter what size</li>
+<li>Largely reduced file size</li>
+</ol>
+<div class="codes">
+<img src="<?=$img_src_1?>" width="512" height="512" alt="QR-Code">
+<img src="<?=$img_src_1?>" width="256" height="256" alt="QR-Code">
+<img src="<?=$img_src_1?>" width="128" height="128" alt="QR-Code">
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
I found some display issue when using the SVG graphics in a HTML img-element or simply editing the file in a graphics tool like Inkscape or Affinity. Although the pixel positions are rounded most devices render thin white flashing lines between the blocks. The lower the resolution the stronger the visual artifacts.

This is not only visually disturbing, but also leads to unwanted fine transparent areas when converting the SVG to bitmap raster graphics (e.g. in GIMP) or when the qr-code is used in a design and transparency reduction ist applied on PDF export.

I described the issue and my solution in detail in this live demo:
[https://demo8.4d-image.de/endroid-qr-code-svgwritercompact/](https://demo8.4d-image.de/endroid-qr-code-svgwritercompact/)

To solve the display issue i render only one SVG path-element with a combined drawing statement for all blocks at once. This fixes the display error in all tested programms. And significantly reduces the overall filesize as well.

The focus is on simple, solid qr-codes for maximum scan readability. I tested the SVG output OK in Inkscape, Affinity, LibreOffice, GIMP and Illustrator.

Maybe you think the new SvgWriterCompact class is a usefull extension.