### PR TITLE
Add optional arguments to interface, to enhance compatibility

### DIFF
--- a/src/Builder/BuilderInterface.php
+++ b/src/Builder/BuilderInterface.php
@@ -4,9 +4,41 @@ declare(strict_types=1);
 
 namespace Endroid\QrCode\Builder;
 
+use Endroid\QrCode\Color\ColorInterface;
+use Endroid\QrCode\Encoding\EncodingInterface;
+use Endroid\QrCode\ErrorCorrectionLevel;
+use Endroid\QrCode\Label\Font\FontInterface;
+use Endroid\QrCode\Label\LabelAlignment;
+use Endroid\QrCode\Label\Margin\MarginInterface;
+use Endroid\QrCode\RoundBlockSizeMode;
 use Endroid\QrCode\Writer\Result\ResultInterface;
+use Endroid\QrCode\Writer\WriterInterface;
 
 interface BuilderInterface
 {
-    public function build(): ResultInterface;
+    public function build(
+        ?WriterInterface $writer = null,
+        ?array $writerOptions = null,
+        ?bool $validateResult = null,
+        // QrCode options
+        ?string $data = null,
+        ?EncodingInterface $encoding = null,
+        ?ErrorCorrectionLevel $errorCorrectionLevel = null,
+        ?int $size = null,
+        ?int $margin = null,
+        ?RoundBlockSizeMode $roundBlockSizeMode = null,
+        ?ColorInterface $foregroundColor = null,
+        ?ColorInterface $backgroundColor = null,
+        // Label options
+        ?string $labelText = null,
+        ?FontInterface $labelFont = null,
+        ?LabelAlignment $labelAlignment = null,
+        ?MarginInterface $labelMargin = null,
+        ?ColorInterface $labelTextColor = null,
+        // Logo options
+        ?string $logoPath = null,
+        ?int $logoResizeToWidth = null,
+        ?int $logoResizeToHeight = null,
+        ?bool $logoPunchoutBackground = null,
+    ): ResultInterface;
 }


### PR DESCRIPTION
In version 6 all methods in `Endroid\QrCode\Builder\Builder` were refactored towards arguments, either in the constructor or in the `build` method. To allow the interface to be compatible, this MR adds the arguments to the `build` method in the interface.