### PR TITLE
Add option for 1bpp PNG

### DIFF
--- a/src/Writer/Png1bppWriter.php
+++ b/src/Writer/Png1bppWriter.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Endroid\QrCode\Writer;
+
+use Endroid\QrCode\Label\LabelInterface;
+use Endroid\QrCode\Logo\LogoInterface;
+use Endroid\QrCode\QrCodeInterface;
+use Endroid\QrCode\Writer\Result\GdResult;
+use Endroid\QrCode\Writer\Result\Png1bppResult;
+use Endroid\QrCode\Writer\Result\ResultInterface;
+
+final readonly class Png1bppWriter extends AbstractGdWriter
+{
+    public const WRITER_OPTION_COMPRESSION_LEVEL = 'compression_level';
+
+    public function write(QrCodeInterface $qrCode, ?LogoInterface $logo = null, ?LabelInterface $label = null, array $options = []): ResultInterface
+    {
+        if (!isset($options[self::WRITER_OPTION_COMPRESSION_LEVEL])) {
+            $options[self::WRITER_OPTION_COMPRESSION_LEVEL] = -1;
+        }
+
+        /** @var GdResult $gdResult */
+        $gdResult = parent::write($qrCode, $logo, $label, $options);
+
+        return new Png1bppResult($gdResult->getMatrix(), $gdResult->getImage(), $options[self::WRITER_OPTION_COMPRESSION_LEVEL]);
+    }
+}

--- a/src/Writer/Result/Png1bppResult.php
+++ b/src/Writer/Result/Png1bppResult.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Endroid\QrCode\Writer\Result;
+
+use Endroid\QrCode\Matrix\MatrixInterface;
+
+final class Png1bppResult extends GdResult
+{
+    public function __construct(
+        MatrixInterface $matrix,
+        \GdImage $image,
+        private readonly int $quality = -1,
+    ) {
+        parent::__construct($matrix, $image);
+    }
+
+    public function getString(): string
+    {
+        ob_start();
+        imagetruecolortopalette($this->image, false, 2);
+        imagepng($this->image, quality: $this->quality);
+
+        return strval(ob_get_clean());
+    }
+
+    public function getMimeType(): string
+    {
+        return 'image/png';
+    }
+}


### PR DESCRIPTION
I had to use 2 color, 1 bit per pixel (1BPP) PNG for a project.
The current default is a 24-bit PNG, which is eventually not ideal for a just black and white QRCode.

Maybe this is useful.
Happy to adapt the PR if someone has a better approach.