### PR TITLE
Upgrade to PHP 8.3+ and implement typed constants and Override attrib…

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['8.2', '8.3', '8.4']
+        php-versions: ['8.3', '8.4', '8.5']
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "bacon/bacon-qr-code": "^3.0"
     },
     "require-dev": {

--- a/src/Writer/AbstractGdWriter.php
+++ b/src/Writer/AbstractGdWriter.php
@@ -27,6 +27,7 @@ abstract readonly class AbstractGdWriter implements WriterInterface, ValidatingW
         return $matrixFactory->create($qrCode);
     }
 
+    #[\Override]
     public function write(QrCodeInterface $qrCode, ?LogoInterface $logo = null, ?LabelInterface $label = null, array $options = []): ResultInterface
     {
         if (!extension_loaded('gd')) {
@@ -195,6 +196,7 @@ abstract readonly class AbstractGdWriter implements WriterInterface, ValidatingW
         return new GdResult($result->getMatrix(), $targetImage);
     }
 
+    #[\Override]
     public function validateResult(ResultInterface $result, string $expectedData): void
     {
         $string = $result->getString();

--- a/src/Writer/BinaryWriter.php
+++ b/src/Writer/BinaryWriter.php
@@ -13,6 +13,7 @@ use Endroid\QrCode\Writer\Result\ResultInterface;
 
 final readonly class BinaryWriter implements WriterInterface
 {
+    #[\Override]
     public function write(QrCodeInterface $qrCode, ?LogoInterface $logo = null, ?LabelInterface $label = null, array $options = []): ResultInterface
     {
         $matrixFactory = new MatrixFactory();

--- a/src/Writer/ConsoleWriter.php
+++ b/src/Writer/ConsoleWriter.php
@@ -13,6 +13,7 @@ use Endroid\QrCode\Writer\Result\ResultInterface;
 
 final readonly class ConsoleWriter implements WriterInterface
 {
+    #[\Override]
     public function write(QrCodeInterface $qrCode, ?LogoInterface $logo = null, ?LabelInterface $label = null, $options = []): ResultInterface
     {
         $matrixFactory = new MatrixFactory();

--- a/src/Writer/DebugWriter.php
+++ b/src/Writer/DebugWriter.php
@@ -13,6 +13,7 @@ use Endroid\QrCode\Writer\Result\ResultInterface;
 
 final readonly class DebugWriter implements WriterInterface, ValidatingWriterInterface
 {
+    #[\Override]
     public function write(QrCodeInterface $qrCode, ?LogoInterface $logo = null, ?LabelInterface $label = null, array $options = []): ResultInterface
     {
         $matrixFactory = new MatrixFactory();
@@ -21,6 +22,7 @@ final readonly class DebugWriter implements WriterInterface, ValidatingWriterInt
         return new DebugResult($matrix, $qrCode, $logo, $label, $options);
     }
 
+    #[\Override]
     public function validateResult(ResultInterface $result, string $expectedData): void
     {
         if (!$result instanceof DebugResult) {

--- a/src/Writer/EpsWriter.php
+++ b/src/Writer/EpsWriter.php
@@ -13,8 +13,9 @@ use Endroid\QrCode\Writer\Result\ResultInterface;
 
 final readonly class EpsWriter implements WriterInterface
 {
-    public const DECIMAL_PRECISION = 10;
+    public const int DECIMAL_PRECISION = 10;
 
+    #[\Override]
     public function write(QrCodeInterface $qrCode, ?LogoInterface $logo = null, ?LabelInterface $label = null, array $options = []): ResultInterface
     {
         $matrixFactory = new MatrixFactory();

--- a/src/Writer/GifWriter.php
+++ b/src/Writer/GifWriter.php
@@ -13,6 +13,7 @@ use Endroid\QrCode\Writer\Result\ResultInterface;
 
 final readonly class GifWriter extends AbstractGdWriter
 {
+    #[\Override]
     public function write(QrCodeInterface $qrCode, ?LogoInterface $logo = null, ?LabelInterface $label = null, array $options = []): ResultInterface
     {
         /** @var GdResult $gdResult */

--- a/src/Writer/PdfWriter.php
+++ b/src/Writer/PdfWriter.php
@@ -13,12 +13,13 @@ use Endroid\QrCode\Writer\Result\ResultInterface;
 
 final readonly class PdfWriter implements WriterInterface
 {
-    public const WRITER_OPTION_UNIT = 'unit';
-    public const WRITER_OPTION_PDF = 'fpdf';
-    public const WRITER_OPTION_X = 'x';
-    public const WRITER_OPTION_Y = 'y';
-    public const WRITER_OPTION_LINK = 'link';
+    public const string WRITER_OPTION_UNIT = 'unit';
+    public const string WRITER_OPTION_PDF = 'fpdf';
+    public const string WRITER_OPTION_X = 'x';
+    public const string WRITER_OPTION_Y = 'y';
+    public const string WRITER_OPTION_LINK = 'link';
 
+    #[\Override]
     public function write(QrCodeInterface $qrCode, ?LogoInterface $logo = null, ?LabelInterface $label = null, array $options = []): ResultInterface
     {
         $matrixFactory = new MatrixFactory();

--- a/src/Writer/PngWriter.php
+++ b/src/Writer/PngWriter.php
@@ -13,9 +13,10 @@ use Endroid\QrCode\Writer\Result\ResultInterface;
 
 final readonly class PngWriter extends AbstractGdWriter
 {
-    public const WRITER_OPTION_COMPRESSION_LEVEL = 'compression_level';
-    public const WRITER_OPTION_NUMBER_OF_COLORS = 'number_of_colors';
+    public const string WRITER_OPTION_COMPRESSION_LEVEL = 'compression_level';
+    public const string WRITER_OPTION_NUMBER_OF_COLORS = 'number_of_colors';
 
+    #[\Override]
     public function write(QrCodeInterface $qrCode, ?LogoInterface $logo = null, ?LabelInterface $label = null, array $options = []): ResultInterface
     {
         if (!isset($options[self::WRITER_OPTION_COMPRESSION_LEVEL])) {

--- a/src/Writer/Result/BinaryResult.php
+++ b/src/Writer/Result/BinaryResult.php
@@ -13,6 +13,7 @@ final class BinaryResult extends AbstractResult
         parent::__construct($matrix);
     }
 
+    #[\Override]
     public function getString(): string
     {
         $matrix = $this->getMatrix();
@@ -28,6 +29,7 @@ final class BinaryResult extends AbstractResult
         return $binaryString;
     }
 
+    #[\Override]
     public function getMimeType(): string
     {
         return 'text/plain';

--- a/src/Writer/Result/ConsoleResult.php
+++ b/src/Writer/Result/ConsoleResult.php
@@ -9,7 +9,7 @@ use Endroid\QrCode\Matrix\MatrixInterface;
 
 final class ConsoleResult extends AbstractResult
 {
-    private const TWO_BLOCKS = [
+    private const array TWO_BLOCKS = [
         0 => ' ',
         1 => "\xe2\x96\x80",
         2 => "\xe2\x96\x84",
@@ -36,11 +36,13 @@ final class ConsoleResult extends AbstractResult
         );
     }
 
+    #[\Override]
     public function getMimeType(): string
     {
         return 'text/plain';
     }
 
+    #[\Override]
     public function getString(): string
     {
         $matrix = $this->getMatrix();

--- a/src/Writer/Result/DebugResult.php
+++ b/src/Writer/Result/DebugResult.php
@@ -29,6 +29,7 @@ final class DebugResult extends AbstractResult
         $this->validateResult = $validateResult;
     }
 
+    #[\Override]
     public function getString(): string
     {
         $debugLines = [];
@@ -67,6 +68,7 @@ final class DebugResult extends AbstractResult
         return implode("\n", $debugLines);
     }
 
+    #[\Override]
     public function getMimeType(): string
     {
         return 'text/plain';

--- a/src/Writer/Result/EpsResult.php
+++ b/src/Writer/Result/EpsResult.php
@@ -16,11 +16,13 @@ final class EpsResult extends AbstractResult
         parent::__construct($matrix);
     }
 
+    #[\Override]
     public function getString(): string
     {
         return implode("\n", $this->lines);
     }
 
+    #[\Override]
     public function getMimeType(): string
     {
         return 'image/eps';

--- a/src/Writer/Result/GdResult.php
+++ b/src/Writer/Result/GdResult.php
@@ -20,11 +20,13 @@ class GdResult extends AbstractResult
         return $this->image;
     }
 
+    #[\Override]
     public function getString(): string
     {
         throw new \Exception('You can only use this method in a concrete implementation');
     }
 
+    #[\Override]
     public function getMimeType(): string
     {
         throw new \Exception('You can only use this method in a concrete implementation');

--- a/src/Writer/Result/GifResult.php
+++ b/src/Writer/Result/GifResult.php
@@ -6,6 +6,7 @@ namespace Endroid\QrCode\Writer\Result;
 
 final class GifResult extends GdResult
 {
+    #[\Override]
     public function getString(): string
     {
         ob_start();
@@ -14,6 +15,7 @@ final class GifResult extends GdResult
         return strval(ob_get_clean());
     }
 
+    #[\Override]
     public function getMimeType(): string
     {
         return 'image/gif';

--- a/src/Writer/Result/PdfResult.php
+++ b/src/Writer/Result/PdfResult.php
@@ -20,11 +20,13 @@ final class PdfResult extends AbstractResult
         return $this->fpdf;
     }
 
+    #[\Override]
     public function getString(): string
     {
         return $this->fpdf->Output('S');
     }
 
+    #[\Override]
     public function getMimeType(): string
     {
         return 'application/pdf';

--- a/src/Writer/Result/PngResult.php
+++ b/src/Writer/Result/PngResult.php
@@ -17,6 +17,7 @@ final class PngResult extends GdResult
         parent::__construct($matrix, $image);
     }
 
+    #[\Override]
     public function getString(): string
     {
         ob_start();
@@ -28,6 +29,7 @@ final class PngResult extends GdResult
         return strval(ob_get_clean());
     }
 
+    #[\Override]
     public function getMimeType(): string
     {
         return 'image/png';

--- a/src/Writer/Result/SvgResult.php
+++ b/src/Writer/Result/SvgResult.php
@@ -21,6 +21,7 @@ final class SvgResult extends AbstractResult
         return $this->xml;
     }
 
+    #[\Override]
     public function getString(): string
     {
         $string = $this->xml->asXML();
@@ -36,6 +37,7 @@ final class SvgResult extends AbstractResult
         return $string;
     }
 
+    #[\Override]
     public function getMimeType(): string
     {
         return 'image/svg+xml';

--- a/src/Writer/Result/WebPResult.php
+++ b/src/Writer/Result/WebPResult.php
@@ -16,6 +16,7 @@ final class WebPResult extends GdResult
         parent::__construct($matrix, $image);
     }
 
+    #[\Override]
     public function getString(): string
     {
         if (!function_exists('imagewebp')) {
@@ -28,6 +29,7 @@ final class WebPResult extends GdResult
         return strval(ob_get_clean());
     }
 
+    #[\Override]
     public function getMimeType(): string
     {
         return 'image/webp';

--- a/src/Writer/SvgWriter.php
+++ b/src/Writer/SvgWriter.php
@@ -15,13 +15,14 @@ use Endroid\QrCode\Writer\Result\SvgResult;
 
 final readonly class SvgWriter implements WriterInterface
 {
-    public const DECIMAL_PRECISION = 2;
-    public const WRITER_OPTION_COMPACT = 'compact';
-    public const WRITER_OPTION_BLOCK_ID = 'block_id';
-    public const WRITER_OPTION_EXCLUDE_XML_DECLARATION = 'exclude_xml_declaration';
-    public const WRITER_OPTION_EXCLUDE_SVG_WIDTH_AND_HEIGHT = 'exclude_svg_width_and_height';
-    public const WRITER_OPTION_FORCE_XLINK_HREF = 'force_xlink_href';
+    public const int DECIMAL_PRECISION = 2;
+    public const string WRITER_OPTION_COMPACT = 'compact';
+    public const string WRITER_OPTION_BLOCK_ID = 'block_id';
+    public const string WRITER_OPTION_EXCLUDE_XML_DECLARATION = 'exclude_xml_declaration';
+    public const string WRITER_OPTION_EXCLUDE_SVG_WIDTH_AND_HEIGHT = 'exclude_svg_width_and_height';
+    public const string WRITER_OPTION_FORCE_XLINK_HREF = 'force_xlink_href';
 
+    #[\Override]
     public function write(QrCodeInterface $qrCode, ?LogoInterface $logo = null, ?LabelInterface $label = null, array $options = []): ResultInterface
     {
         if (!isset($options[self::WRITER_OPTION_COMPACT])) {

--- a/src/Writer/WebPWriter.php
+++ b/src/Writer/WebPWriter.php
@@ -13,8 +13,9 @@ use Endroid\QrCode\Writer\Result\WebPResult;
 
 final readonly class WebPWriter extends AbstractGdWriter
 {
-    public const WRITER_OPTION_QUALITY = 'quality';
+    public const string WRITER_OPTION_QUALITY = 'quality';
 
+    #[\Override]
     public function write(QrCodeInterface $qrCode, ?LogoInterface $logo = null, ?LabelInterface $label = null, array $options = []): ResultInterface
     {
         if (!isset($options[self::WRITER_OPTION_QUALITY])) {


### PR DESCRIPTION
…utes

- Update minimum PHP version from 8.2 to 8.3 in composer.json
- Update CI workflow to test PHP 8.3, 8.4, and 8.5
- Add typed class constants (PHP 8.3 feature) to all Writer classes
- Add #[\Override] attributes (PHP 8.3 feature) to all methods that override parent/interface methods
- Improve type safety and catch potential refactoring errors at compile time

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minimum PHP version requirement updated from 8.2 to 8.3
  * Added support for PHP 8.5
  * Improved code quality with explicit type declarations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->