### PR TITLE
Extract addBlock in GdTrait so we can extend it to draw custom shapes

### DIFF
--- a/src/Writer/GdTrait.php
+++ b/src/Writer/GdTrait.php
@@ -68,12 +68,11 @@ trait GdTrait
         for ($rowIndex = 0; $rowIndex < $matrix->getBlockCount(); ++$rowIndex) {
             for ($columnIndex = 0; $columnIndex < $matrix->getBlockCount(); ++$columnIndex) {
                 if (1 === $matrix->getBlockValue($rowIndex, $columnIndex)) {
-                    imagefilledrectangle(
+                    $this->addBlock(
                         $baseImage,
-                        $columnIndex * $baseBlockSize,
-                        $rowIndex * $baseBlockSize,
-                        ($columnIndex + 1) * $baseBlockSize - 1,
-                        ($rowIndex + 1) * $baseBlockSize - 1,
+                        $rowIndex,
+                        $columnIndex,
+                        $baseBlockSize,
                         $foregroundColor
                     );
                 }
@@ -229,5 +228,26 @@ trait GdTrait
         if ($reader->text() !== $expectedData) {
             throw ValidationException::createForInvalidData($expectedData, strval($reader->text()));
         }
+    }
+
+    /**
+     * Draws a single square (block) to the image.
+     * Can be overwritten to use custom shapes instead of squares.
+     */
+    public function addBlock(
+        \GdImage $baseImage,
+        int $rowIndex,
+        int $columnIndex,
+        int $baseBlockSize,
+        int $foregroundColor
+    ): void {
+        imagefilledrectangle(
+            $baseImage,
+            $columnIndex * $baseBlockSize,
+            $rowIndex * $baseBlockSize,
+            ($columnIndex + 1) * $baseBlockSize - 1,
+            ($rowIndex + 1) * $baseBlockSize - 1,
+            $foregroundColor
+        );
     }
 }

--- a/src/Writer/PngWriter.php
+++ b/src/Writer/PngWriter.php
@@ -10,7 +10,7 @@ use Endroid\QrCode\QrCodeInterface;
 use Endroid\QrCode\Writer\Result\PngResult;
 use Endroid\QrCode\Writer\Result\ResultInterface;
 
-final readonly class PngWriter implements WriterInterface, ValidatingWriterInterface
+readonly class PngWriter implements WriterInterface, ValidatingWriterInterface
 {
     use GdTrait;
 


### PR DESCRIPTION
As QR Codes do work with circles or partly rounded shapes, extracting the "addBlock" method allows to create custom writers, using the GdTrait but overwriting the addBlock method

example:

```
<?php

namespace App\Service;

use Endroid\QrCode\Writer\PngWriter;

readonly class PngShapeWriter extends PngWriter
{
    public function addBlock(
        \GdImage $baseImage,
        int $rowIndex,
        int $columnIndex,
        int $baseBlockSize,
        int $foregroundColor,
    ): void {

        // will draw a circle instead of a square
        imagefilledellipse(
            $baseImage,
            $columnIndex * $baseBlockSize + $baseBlockSize/2,
            $rowIndex * $baseBlockSize + $baseBlockSize/2,
            $baseBlockSize - 1,
            $baseBlockSize - 1,
            $foregroundColor
        );
    }
}
```
